### PR TITLE
Add function to validate origin in WebTracker controller

### DIFF
--- a/lib/web/controllers/web_tracker_controller.ex
+++ b/lib/web/controllers/web_tracker_controller.ex
@@ -94,6 +94,7 @@ defmodule Web.WebTrackerController do
         :ok
     end
   end
+  defp validate_origin(_), do: {:error, :origin_not_configured}
 
   @spec validate_visitor_id(String.t() | nil) :: {:ok, String.t()} | {:error, :missing_visitor_id}
   defp validate_visitor_id(visitor_id) when is_binary(visitor_id) and visitor_id != "", do: {:ok, visitor_id}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `validate_origin/1` in `web_tracker_controller.ex` to handle unconfigured origins in `create` function.
> 
>   - **Behavior**:
>     - Adds `validate_origin/1` function in `web_tracker_controller.ex` to handle unconfigured origins.
>     - Returns `{:error, :origin_not_configured}` for unconfigured origins in `create` function.
>   - **Functions**:
>     - Adds `validate_origin/1` to handle origin validation logic.
>     - Updates `create` function to use `validate_origin/1` for origin validation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for 8aa84fd98617331fd94d3e5b213246df99092cc9. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->