### PR TITLE
Add ApiCallLogger module to log external API calls made with Finch.

### DIFF
--- a/lib/core/api_call_logger/schema.ex
+++ b/lib/core/api_call_logger/schema.ex
@@ -1,0 +1,60 @@
+defmodule Core.ApiCallLogger.Schema do
+  @moduledoc """
+  Schema for logging API calls to external services.
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:id, :string, autogenerate: false}
+  @foreign_key_type :string
+
+  # Constants
+  @id_prefix "api"
+  @id_regex ~r/^#{@id_prefix}_[a-z0-9]{21}$/
+
+  schema "api_call_logs" do
+    field :vendor, :string
+    field :method, :string
+    field :url, :string
+    field :request_body, :binary
+    field :duration, :integer
+    field :status_code, :integer
+    field :response_body, :binary
+    field :error_message, :string
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @type t :: %__MODULE__{
+    id: String.t(),
+    vendor: String.t(),
+    method: String.t(),
+    url: String.t(),
+    request_body: binary() | nil,
+    duration: integer(),
+    status_code: integer() | nil,
+    response_body: binary() | nil,
+    error_message: String.t() | nil,
+    inserted_at: DateTime.t(),
+    updated_at: DateTime.t()
+  }
+
+  @doc """
+  Returns the ID prefix used for API call logs.
+  """
+  def id_prefix, do: @id_prefix
+
+  @doc """
+  Validates the changeset for an API call log.
+  """
+  def changeset(log, attrs) do
+    log
+    |> cast(attrs, [
+      :id, :vendor, :method, :url, :request_body,
+      :duration, :status_code, :response_body, :error_message
+    ])
+    |> validate_required([:id, :vendor, :method, :url, :duration])
+    |> validate_format(:id, @id_regex)
+  end
+end

--- a/lib/core/external/snitcher/service.ex
+++ b/lib/core/external/snitcher/service.ex
@@ -5,6 +5,10 @@ defmodule Core.External.Snitcher.Service do
   """
   require Logger
 
+  alias Core.ApiCallLogger.Logger, as: ApiLogger
+
+  @vendor "snitcher"
+
   @doc """
   Identifies company information from an IP address using Snitcher service.
   """
@@ -30,15 +34,7 @@ defmodule Core.External.Snitcher.Service do
 
     :post
     |> Finch.build(url, headers, "")
-    |> Finch.request(Core.Finch)
-    |> case do
-      {:ok, response} ->
-        {:ok, response}
-
-      {:error, reason} ->
-        Logger.error("Snitcher request failed: #{inspect(reason)}")
-        {:error, :request_failed}
-    end
+    |> ApiLogger.request(@vendor)
   end
 
   defp parse_response(%Finch.Response{status: 200, body: body}) do

--- a/priv/repo/migrations/20240320000000_create_api_call_logs.exs
+++ b/priv/repo/migrations/20240320000000_create_api_call_logs.exs
@@ -1,0 +1,24 @@
+defmodule Core.Repo.Migrations.CreateApiCallLogs do
+  use Ecto.Migration
+
+  def change do
+    create table(:api_call_logs, primary_key: false) do
+      add :id, :string, primary_key: true
+      add :vendor, :string, null: false
+      add :method, :string, null: false
+      add :url, :string, null: false
+      add :request_body, :binary
+      add :duration, :integer, null: false
+      add :status_code, :integer
+      add :response_body, :binary
+      add :error_message, :text
+
+      timestamps(type: :utc_datetime)
+    end
+
+    # Create indexes for common queries
+    create index(:api_call_logs, [:vendor])
+    create index(:api_call_logs, [:inserted_at])
+    create index(:api_call_logs, [:vendor, :inserted_at])
+  end
+end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `ApiCallLogger` module for logging external API calls and update services to use it.
> 
>   - **New Module**:
>     - `Core.ApiCallLogger.Logger` handles logging of external API calls made with Finch.
>     - Redacts sensitive parameters in URLs.
>     - Logs success and error responses to the database using `Core.ApiCallLogger.Schema`.
>   - **Schema**:
>     - `Core.ApiCallLogger.Schema` defines the Ecto schema for `api_call_logs`.
>     - Includes fields for `vendor`, `method`, `url`, `request_body`, `duration`, `status_code`, `response_body`, and `error_message`.
>   - **Migration**:
>     - `20240320000000_create_api_call_logs.exs` creates `api_call_logs` table with appropriate fields and indexes.
>   - **Service Updates**:
>     - `Core.External.IPData.Service` and `Core.External.Snitcher.Service` updated to use `ApiLogger` for API requests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for aa4756f3e36f7948180c7b2ba6874cdeced23344. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->