### PR TITLE
Add last_event_at field to WebSession model

### DIFF
--- a/lib/core/utils/id_generator.ex
+++ b/lib/core/utils/id_generator.ex
@@ -23,7 +23,7 @@ defmodule Core.Utils.IdGenerator do
     "#{prefix}_#{Nanoid.generate(16, @alphabet)}"
   end
 
-  @spec generate_id(Integer.t()) :: String.t()
+  @spec generate_id(integer()) :: String.t()
   def generate_id(size \\ 21) when is_integer(size) and size != 0 do
     Nanoid.generate(size, @alphabet)
   end

--- a/lib/core/web_tracker/schemas/web_session.ex
+++ b/lib/core/web_tracker/schemas/web_session.ex
@@ -30,6 +30,7 @@ defmodule Core.WebTracker.Schemas.WebSession do
     # Custom timestamps
     field :started_at, :utc_datetime
     field :ended_at, :utc_datetime
+    field :last_event_at, :utc_datetime
     field :created_at, :utc_datetime
     field :updated_at, :utc_datetime
   end
@@ -50,6 +51,7 @@ defmodule Core.WebTracker.Schemas.WebSession do
     # Timestamps
     started_at: DateTime.t() | nil,
     ended_at: DateTime.t() | nil,
+    last_event_at: DateTime.t() | nil,
     created_at: DateTime.t(),
     updated_at: DateTime.t()
   }
@@ -67,7 +69,7 @@ defmodule Core.WebTracker.Schemas.WebSession do
     |> cast(attrs, [
       :id, :tenant, :visitor_id, :origin, :active, :metadata,
       :ip, :city, :region, :country_code, :is_mobile,
-      :started_at, :ended_at, :created_at, :updated_at
+      :started_at, :ended_at, :last_event_at, :created_at, :updated_at
     ])
     |> validate_required([:id, :tenant, :visitor_id, :origin, :created_at, :updated_at])
     |> validate_format(:id, @id_regex)

--- a/lib/core/web_tracker/web_sessions.ex
+++ b/lib/core/web_tracker/web_sessions.ex
@@ -20,6 +20,7 @@ defmodule Core.WebTracker.WebSessions do
       |> Map.put(:created_at, now)
       |> Map.put(:updated_at, now)
       |> Map.put(:started_at, now)
+      |> Map.put(:last_event_at, now)
 
     %WebSession{}
     |> WebSession.changeset(attrs)
@@ -39,5 +40,17 @@ defmodule Core.WebTracker.WebSessions do
              s.active == true
     )
     |> Repo.one()
+  end
+
+  @doc """
+  Updates the last_event_at timestamp for a session.
+  """
+  @spec update_last_event_at(WebSession.t()) :: {:ok, WebSession.t()} | {:error, Ecto.Changeset.t()}
+  def update_last_event_at(%WebSession{} = session) do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    session
+    |> WebSession.changeset(%{last_event_at: now, updated_at: now})
+    |> Repo.update()
   end
 end

--- a/lib/core/web_tracker/web_tracker.ex
+++ b/lib/core/web_tracker/web_tracker.ex
@@ -117,10 +117,10 @@ defmodule Core.WebTracker do
       timestamp: attrs.timestamp
     }
 
-    case WebTrackerEvents.create(event_attrs) do
-      {:ok, _event} ->
-        {:ok, %{status: :accepted, session_id: session.id}}
-
+    with {:ok, _event} <- WebTrackerEvents.create(event_attrs),
+         {:ok, _session} <- WebSessions.update_last_event_at(session) do
+      {:ok, %{status: :accepted, session_id: session.id}}
+    else
       {:error, _changeset} ->
         {:error, :internal_server_error, "failed to create event"}
     end

--- a/priv/repo/migrations/20250521132708_add_last_event_at_to_web_sessions.exs
+++ b/priv/repo/migrations/20250521132708_add_last_event_at_to_web_sessions.exs
@@ -1,0 +1,12 @@
+defmodule Core.Repo.Migrations.AddLastEventAtToWebSessions do
+  use Ecto.Migration
+
+  def change do
+    alter table(:web_sessions) do
+      add :last_event_at, :utc_datetime, null: false
+    end
+
+    # Create an index for last_event_at for better query performance
+    create index(:web_sessions, [:last_event_at])
+  end
+end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `last_event_at` field to `WebSession` model and update related logic for session and event management.
> 
>   - **Schema Changes**:
>     - Add `last_event_at` field to `WebSession` schema in `web_session.ex`.
>     - Update `changeset` function in `web_session.ex` to include `last_event_at`.
>   - **Database Migration**:
>     - Add migration `20250521132708_add_last_event_at_to_web_sessions.exs` to add `last_event_at` column and index to `web_sessions` table.
>   - **Session Management**:
>     - Update `create` function in `web_sessions.ex` to set `last_event_at` to current time.
>     - Add `update_last_event_at` function in `web_sessions.ex` to update `last_event_at` timestamp.
>   - **Event Processing**:
>     - Modify `process_new_event` in `web_tracker.ex` to update `last_event_at` when an event is processed.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for 27a34b8fc01739be8f07f4236c2da88b2d194b5c. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->