### PR TITLE
Add Core.WebTracker.WebSessionCloser and assign default env var value…

### DIFF
--- a/lib/application.ex
+++ b/lib/application.ex
@@ -22,7 +22,8 @@ defmodule Core.Application do
       ## 3rd party
       {DNSCluster,
        query: Application.get_env(:core, :dns_cluster_query) || :ignore},
-      {Finch, name: Core.Finch}
+      {Finch, name: Core.Finch},
+      Core.WebTracker.WebSessionCloser
     ]
 
     env = Application.get_env(:core, :app_env, :prod)

--- a/lib/core/web_tracker/web_session_closer.ex
+++ b/lib/core/web_tracker/web_session_closer.ex
@@ -1,0 +1,59 @@
+defmodule Core.WebTracker.WebSessionCloser do
+  @moduledoc """
+  GenServer responsible for periodically closing inactive web sessions.
+  """
+  use GenServer
+  require Logger
+  alias Core.WebTracker.WebSessions
+
+  # Default interval is 2 minutes
+  @default_interval_ms 2 * 60 * 1000
+  # Process 100 sessions at a time by default
+  @default_batch_size 100
+
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @impl true
+  def init(opts) do
+    interval_ms = Keyword.get(opts, :interval_ms, @default_interval_ms)
+    batch_size = Keyword.get(opts, :batch_size, @default_batch_size)
+
+    # Schedule the first check
+    schedule_check(interval_ms)
+
+    {:ok, %{interval_ms: interval_ms, batch_size: batch_size}}
+  end
+
+  @impl true
+  def handle_info(:check_sessions, %{interval_ms: interval_ms, batch_size: batch_size} = state) do
+    close_inactive_sessions(batch_size)
+    schedule_check(interval_ms)
+    {:noreply, state}
+  end
+
+  # Schedule the next check
+  defp schedule_check(interval_ms) do
+    Process.send_after(self(), :check_sessions, interval_ms)
+  end
+
+  # Close inactive sessions
+  defp close_inactive_sessions(batch_size) do
+    # Get sessions that need to be closed
+    sessions = WebSessions.get_sessions_to_close(batch_size)
+
+    # Close each session and log the result
+    Enum.each(sessions, &close_session/1)
+  end
+
+  defp close_session(session) do
+    case WebSessions.close(session) do
+      {:ok, closed_session} ->
+        Logger.info("Closed web session: #{closed_session.id}")
+
+      {:error, changeset} ->
+        Logger.error("Failed to close web session: #{session.id}, errors: #{inspect(changeset.errors)}")
+    end
+  end
+end

--- a/lib/core/web_tracker/web_sessions.ex
+++ b/lib/core/web_tracker/web_sessions.ex
@@ -94,4 +94,22 @@ defmodule Core.WebTracker.WebSessions do
     )
     |> Repo.all()
   end
+
+  @doc """
+  Closes a web session by setting active to false and ended_at to the last_event_at timestamp.
+  Returns {:ok, session} if closed successfully or if already closed.
+  """
+  @spec close(WebSession.t()) :: {:ok, WebSession.t()} | {:error, Ecto.Changeset.t() | String.t()}
+  def close(%WebSession{} = session) when is_nil(session.id),
+    do: {:error, "Session ID is required"}
+  def close(%WebSession{active: false} = session),
+    do: {:ok, session}  # Session already closed, return as is
+  def close(%WebSession{} = session) do
+    session
+    |> WebSession.changeset(%{
+      active: false,
+      ended_at: session.last_event_at
+    })
+    |> Repo.update()
+  end
 end


### PR DESCRIPTION
…s in application module.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `Core.WebTracker.WebSessionCloser` to periodically close inactive web sessions, integrated into the application supervision tree.
> 
>   - **Behavior**:
>     - Adds `Core.WebTracker.WebSessionCloser` GenServer to periodically close inactive web sessions.
>     - Integrated into supervision tree in `application.ex`.
>   - **WebSessionCloser**:
>     - Default interval of 2 minutes and batch size of 100 sessions.
>     - Uses `handle_info/2` to schedule and process session closure.
>   - **WebSessions**:
>     - Adds `close/1` function to close sessions by setting `active` to false and updating `ended_at`.
>     - `get_sessions_to_close/1` retrieves sessions based on inactivity criteria.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for 55f1f8a161a12027bc76c3ac7724634a10d9bc0f. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->