### PR TITLE
Add Leads context and schema with migration

### DIFF
--- a/lib/core/crm/leads.ex
+++ b/lib/core/crm/leads.ex
@@ -1,0 +1,41 @@
+defmodule Core.Crm.Leads do
+  @moduledoc """
+  The Leads context.
+  """
+
+  import Ecto.Query, warn: false
+  alias Core.Repo
+  alias Core.Crm.Leads.Lead
+  alias Core.Auth.Tenants
+
+  def get_by_ref_id(tenant_id, ref_id) do
+    Repo.get_by(Lead, tenant_id: tenant_id, ref_id: ref_id)
+  end
+
+  def list_by_tenant_id(tenant_id) do
+    Repo.all(Lead, where: [tenant_id: tenant_id])
+  end
+
+  def get_or_create(tenant, attrs) do
+    case Tenants.get_tenant_by_name(tenant) do
+      nil ->
+        {:error, :not_found, "Tenant not found"}
+
+      %Tenants.Tenant{id: tenant_id} ->
+        case get_by_ref_id(tenant_id, attrs.ref_id) do
+          nil ->
+            %Lead{}
+            |> Lead.changeset(%{
+              tenant_id: tenant_id,
+              ref_id: attrs.ref_id,
+              type: attrs.type,
+              stage: Map.get(attrs, :stage, :target)
+            })
+            |> Repo.insert()
+
+          lead ->
+            {:ok, lead}
+        end
+    end
+  end
+end

--- a/lib/core/crm/leads/lead.ex
+++ b/lib/core/crm/leads/lead.ex
@@ -1,0 +1,31 @@
+defmodule Core.Crm.Leads.Lead do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:id, :string, autogenerate: false}
+  schema "leads" do
+    field(:tenant_id, :string)
+    field(:ref_id, :string)
+    field(:type, Ecto.Enum, values: [:contact, :company])
+
+    field(:stage, Ecto.Enum,
+      values: [:target, :education, :solution, :evaluation, :ready_to_buy],
+      default: :target
+    )
+
+    timestamps(type: :utc_datetime)
+  end
+
+  def changeset(%__MODULE__{} = lead, attrs) do
+    lead
+    |> cast(attrs, [:id, :tenant_id, :ref_id, :type, :stage])
+    |> maybe_put_id()
+    |> validate_required([:tenant_id, :ref_id, :type])
+  end
+
+  defp maybe_put_id(%Ecto.Changeset{data: %{id: nil}} = changeset) do
+    put_change(changeset, :id, Core.Utils.IdGenerator.generate_id_21("lead"))
+  end
+
+  defp maybe_put_id(changeset), do: changeset
+end

--- a/priv/repo/migrations/20250522132259_create_leads_table.exs
+++ b/priv/repo/migrations/20250522132259_create_leads_table.exs
@@ -1,0 +1,21 @@
+defmodule Core.Repo.Migrations.CreateLeadsTable do
+  use Ecto.Migration
+
+  def change do
+    execute "CREATE TYPE lead_type AS ENUM ('contact', 'company')",
+            "DROP TYPE lead_type"
+
+    execute "CREATE TYPE lead_stage AS ENUM ('target', 'education', 'solution', 'evaluation', 'ready_to_buy')",
+            "DROP TYPE lead_stage"
+
+    create table(:leads, primary_key: false) do
+      add :id, :string, null: false
+      add :tenant_id, :string, null: false
+      add :ref_id, :string, null: false
+      add :type, :lead_type, null: false
+      add :stage, :lead_stage, null: false, default: "target"
+
+      timestamps()
+    end
+  end
+end


### PR DESCRIPTION
- Implement `Core.Crm.Leads` module for managing leads
- Add `Core.Crm.Leads.Lead` schema with Ecto enums for type and stage
- Create migration for `leads` table with custom types
- Integrate lead creation in `Core.WebTracker` for company domains
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `Core.Crm.Leads` module with schema and migration for leads, and integrate lead creation in `Core.WebTracker`.
> 
>   - **Core.Crm.Leads Module**:
>     - New module `Core.Crm.Leads` for managing leads.
>     - Functions `get_by_ref_id/2`, `list_by_tenant_id/1`, and `get_or_create/2` added.
>   - **Schema and Migration**:
>     - New schema `Core.Crm.Leads.Lead` with fields `tenant_id`, `ref_id`, `type`, and `stage`.
>     - Ecto enums for `type` and `stage` in `lead.ex`.
>     - Migration `20250522132259_create_leads_table.exs` creates `leads` table with custom types.
>   - **Integration**:
>     - `Core.WebTracker` updated to integrate lead creation for company domains using `get_or_create/2`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for 538eaa1ce7d78cd4df0c0780c1f868aabbf38616. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->