### PR TITLE
Add validation for personal email domain

### DIFF
--- a/lib/core/auth/users/user.ex
+++ b/lib/core/auth/users/user.ex
@@ -60,7 +60,7 @@ defmodule Core.Auth.Users.User do
     case get_change(changeset, :email) do
       nil -> changeset
       email ->
-        case Domain.extract_domain_from_email(email) do
+        case Domain.extract_domain_from_email(String.downcase(email)) do
           {:ok, domain} ->
             if PersonalEmailProviders.exists?(domain) do
               add_error(changeset, :email, "cannot use a personal email")

--- a/lib/core/auth/users/user_notifier.ex
+++ b/lib/core/auth/users/user_notifier.ex
@@ -48,7 +48,7 @@ defmodule Core.Auth.Users.UserNotifier do
     {html, text} = render_content(&login_content/1, %{url: url})
 
     deliver(
-      to: user.email,
+      to: usxr.email,
       subject: "Sign in to CustomerOS",
       html_body: html,
       text_body: text,

--- a/lib/core/auth/users/user_notifier.ex
+++ b/lib/core/auth/users/user_notifier.ex
@@ -48,7 +48,7 @@ defmodule Core.Auth.Users.UserNotifier do
     {html, text} = render_content(&login_content/1, %{url: url})
 
     deliver(
-      to: usxr.email,
+      to: user.email,
       subject: "Sign in to CustomerOS",
       html_body: html,
       text_body: text,

--- a/lib/core/utils/domain.ex
+++ b/lib/core/utils/domain.ex
@@ -67,4 +67,15 @@ defmodule Core.Utils.Domain do
     |> String.trim("/")
     |> String.trim()
   end
+
+  def extract_domain_from_email(email) when is_binary(email) and byte_size(email) > 0 do
+    case String.split(email, "@", parts: 2) do
+      [_, domain] when byte_size(domain) > 0 ->
+        validate_domain(domain)
+      _ ->
+        {:error, :invalid_email_format}
+    end
+  end
+  def extract_domain_from_email(""), do: {:error, :invalid_email_format}
+  def extract_domain_from_email(nil), do: {:error, :invalid_email_format}
 end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds validation to prevent registration with personal email domains by extracting and checking email domains.
> 
>   - **Validation**:
>     - Adds `validate_personal_email_domain()` in `user.ex` to prevent registration with personal email domains.
>     - Uses `Domain.extract_domain_from_email()` to extract domain from email.
>     - Checks domain against `PersonalEmailProviders.exists?()`.
>   - **Domain Extraction**:
>     - Adds `extract_domain_from_email()` in `domain.ex` to extract domain from email string.
>     - Validates domain format and handles invalid email formats.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for 2dd6c8ed7da5644bf3804ce22ae1a0241089ab77. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->