### PR TITLE
Create ICP for tenant in Research Orchestrator

### DIFF
--- a/lib/core/auth/tenants.ex
+++ b/lib/core/auth/tenants.ex
@@ -43,7 +43,7 @@ defmodule Core.Auth.Tenants do
     case create_tenant_and_return_id(name, domain) do
       {:ok, tenant_id} ->
         tenant_id
-        |> Core.Icp.ProfileManager.create_icp_for_tenant()
+        |> Core.Research.Orchestrator.create_icp_for_tenant()
 
       {:error, changeset} ->
         {:error, changeset}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> In `tenants.ex`, `create_tenant_and_build_icp()` now uses `Research.Orchestrator` for ICP creation instead of `ProfileManager`.
> 
>   - **Behavior**:
>     - In `tenants.ex`, `create_tenant_and_build_icp()` now calls `Core.Research.Orchestrator.create_icp_for_tenant()` instead of `Core.Icp.ProfileManager.create_icp_for_tenant()`.
>   - **Responsibility Shift**:
>     - Responsibility for creating ICPs moved from `ProfileManager` to `Research.Orchestrator`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for 37545495be5da8908292cf57577ab784a3377070. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->