### PR TITLE
Add Slack notification for new tenant registration.

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -34,6 +34,9 @@ config :core,
   ai: [
     anthropic_api_path: "https://api.anthropic.com/v1/messages",
     default_llm_timeout: 45_000
+  ],
+  slack: [
+    new_tenant_webhook_url: System.get_env("SLACK_NEW_TENANT_WEBHOOK_URL")
   ]
 
 # Esbuild configuration

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -126,3 +126,7 @@ config :ex_aws, :s3,
 
 # Brandfetch configuration
 config :core, :brandfetch, client_id: get_env.("BRANDFETCH_CLIENT_ID", nil)
+
+# Slack configuration
+config :core, :slack,
+  new_tenant_webhook_url: get_env.("SLACK_NEW_TENANT_WEBHOOK_URL", nil)

--- a/lib/core/auth/tenants.ex
+++ b/lib/core/auth/tenants.ex
@@ -4,9 +4,10 @@ defmodule Core.Auth.Tenants do
   """
 
   import Ecto.Query, warn: false
+  require Logger
   alias Core.Repo
-
   alias Core.Auth.Tenants.Tenant
+  alias Core.Notifications.Slack
 
   ## Database getters
 
@@ -27,9 +28,23 @@ defmodule Core.Auth.Tenants do
   ## Tenant registration
 
   def create_tenant(name, domain) do
-    %Tenant{}
-    |> Tenant.changeset(%{name: name, domain: domain})
-    |> Repo.insert()
+    case %Tenant{}
+         |> Tenant.changeset(%{name: name, domain: domain})
+         |> Repo.insert() do
+      {:ok, tenant} = result ->
+        # Notify Slack about new tenant
+        Task.start(fn ->
+          case Slack.notify_new_tenant(tenant.name, tenant.domain) do
+            :ok -> :ok
+            {:error, reason} ->
+              Logger.error("Failed to send Slack notification for tenant #{tenant.name} creation: #{inspect(reason)}")
+          end
+        end)
+        result
+
+      error ->
+        error
+    end
   end
 
   def create_tenant_and_return_id(name, domain) do

--- a/lib/core/notifications/slack.ex
+++ b/lib/core/notifications/slack.ex
@@ -1,0 +1,79 @@
+defmodule Core.Notifications.Slack do
+  @moduledoc """
+  Handles Slack notifications for various system events.
+  Provides both generic Slack message sending and specific notification types.
+  """
+
+  require Logger
+
+  @doc """
+  Generic function to send a message to Slack.
+  Returns :ok on success or {:error, reason} on failure.
+  """
+  @spec send_message(String.t(), map()) :: :ok | {:error, :slack_api_error | Finch.Error.t()}
+  def send_message(webhook_url, message) when is_binary(webhook_url) and is_map(message) do
+    case Finch.request(Core.Finch, :post, webhook_url, [{"Content-Type", "application/json"}], Jason.encode!(message)) do
+      {:ok, %{status: 200}} ->
+        :ok
+
+      {:ok, %{status: status_code}} ->
+        Logger.error("Slack API returned status code #{status_code}")
+        {:error, :slack_api_error}
+
+      {:error, %Finch.Error{} = error} ->
+        Logger.error("Failed to send Slack message: #{inspect(error)}")
+        {:error, error}
+    end
+  end
+
+  @doc """
+  Sends a notification about a new tenant registration.
+  Includes tenant name, domain, and registration timestamp.
+  """
+  @spec notify_new_tenant(String.t(), String.t()) :: :ok | {:error, :webhook_not_configured | :slack_api_error | Finch.Error.t()}
+  def notify_new_tenant(name, domain) when is_binary(name) and is_binary(domain) do
+    webhook_url = Application.get_env(:core, :slack)[:new_tenant_webhook_url]
+
+    unless webhook_url do
+      Logger.warning("Slack new tenant webhook URL not configured")
+      {:error, :webhook_not_configured}
+    else
+      message = %{
+        blocks: [
+          %{
+            type: "header",
+            text: %{
+              type: "plain_text",
+              text: "🏢 New Tenant Registration",
+              emoji: true
+            }
+          },
+          %{
+            type: "section",
+            fields: [
+              %{
+                type: "mrkdwn",
+                text: "*Tenant Name:*\n#{name}"
+              },
+              %{
+                type: "mrkdwn",
+                text: "*Domain:*\n#{domain}"
+              }
+            ]
+          },
+          %{
+            type: "context",
+            elements: [
+              %{
+                type: "mrkdwn",
+                text: "Registered at: #{DateTime.utc_now() |> Calendar.strftime("%Y-%m-%d %H:%M:%S UTC")}"
+              }
+            ]
+          }
+        ]
+      }
+
+      send_message(webhook_url, message)
+    end
+  end
+end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds Slack notification for new tenant registration, updating configurations and implementing notification handling in `slack.ex`.
> 
>   - **Behavior**:
>     - Adds Slack notification for new tenant registration in `create_tenant()` in `tenants.ex`.
>     - Sends tenant name, domain, and registration timestamp to Slack.
>     - Logs error if Slack notification fails.
>   - **Configuration**:
>     - Adds `slack` configuration with `new_tenant_webhook_url` in `config.exs` and `runtime.exs`.
>   - **Notifications**:
>     - New module `slack.ex` for handling Slack notifications.
>     - Implements `send_message()` and `notify_new_tenant()` functions in `slack.ex`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for 0f71e84e7a4bf5dc4f5a347554a224fa354afb31. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->