### PR TITLE
patch: Add enrichment attempt counters to companies

### DIFF
--- a/lib/application.ex
+++ b/lib/application.ex
@@ -19,6 +19,8 @@ defmodule Core.Application do
       Core.Repo,
       Core.Researcher.Orchestrator,
       Core.Crm.Companies.Enrich,
+      Core.Crm.Companies.CompanyEnricher,
+      Core.WebTracker.WebSessionCloser,
       Web.Endpoint,
       Web.Presence,
       Web.Telemetry,
@@ -26,8 +28,7 @@ defmodule Core.Application do
       ## 3rd party
       {DNSCluster,
        query: Application.get_env(:core, :dns_cluster_query) || :ignore},
-      {Finch, name: Core.Finch},
-      Core.WebTracker.WebSessionCloser
+      {Finch, name: Core.Finch}
     ]
 
     env = Application.get_env(:core, :app_env, :prod)

--- a/lib/core/crm/companies/company.ex
+++ b/lib/core/crm/companies/company.ex
@@ -22,6 +22,12 @@ defmodule Core.Crm.Companies.Company do
     field(:country_enrich_attempt_at, :utc_datetime)
     field(:logo_enrich_attempt_at, :utc_datetime)
 
+    # Enrichment attempt counters
+    field(:industry_enrichment_attempts, :integer, default: 0)
+    field(:name_enrichment_attempts, :integer, default: 0)
+    field(:country_enrichment_attempts, :integer, default: 0)
+    field(:logo_enrichment_attempts, :integer, default: 0)
+
     # LinkedIn fields
     field(:linkedin_id, :string)
     field(:linkedin_alias, :string)
@@ -47,6 +53,11 @@ defmodule Core.Crm.Companies.Company do
           name_enrich_attempt_at: DateTime.t() | nil,
           country_enrich_attempt_at: DateTime.t() | nil,
           logo_enrich_attempt_at: DateTime.t() | nil,
+          # Enrichment attempt counters
+          industry_enrichment_attempts: integer(),
+          name_enrichment_attempts: integer(),
+          country_enrichment_attempts: integer(),
+          logo_enrichment_attempts: integer(),
           # LinkedIn fields
           linkedin_id: String.t() | nil,
           linkedin_alias: String.t() | nil,
@@ -73,6 +84,10 @@ defmodule Core.Crm.Companies.Company do
       :name_enrich_attempt_at,
       :country_enrich_attempt_at,
       :logo_enrich_attempt_at,
+      :industry_enrichment_attempts,
+      :name_enrichment_attempts,
+      :country_enrichment_attempts,
+      :logo_enrichment_attempts,
       :linkedin_id,
       :linkedin_alias,
       :homepage_content

--- a/lib/core/crm/companies/company_enricher.ex
+++ b/lib/core/crm/companies/company_enricher.ex
@@ -1,0 +1,61 @@
+defmodule Core.Crm.Companies.CompanyEnricher do
+  @moduledoc """
+  GenServer responsible for periodically enriching company data.
+  Runs every 15 minutes and processes companies that need enrichment for various fields:
+  - Logo
+  # - Industry
+  # - Name
+  # - Country
+  """
+  use GenServer
+  require Logger
+
+  alias Core.Crm.Companies.Enrich
+
+  @default_interval_ms 15 * 60 * 1000
+  @default_batch_size 20
+
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @impl true
+  def init(_opts) do
+    # Schedule the first check
+    schedule_check(@default_interval_ms)
+
+    {:ok, %{}}
+  end
+
+  @impl true
+  def handle_info(:enrich_companies, state) do
+    companiesForLogoEnrichment = Enrich.fetch_companies_for_logo_enrichment(@default_batch_size)
+    company_count = length(companiesForLogoEnrichment)
+
+    # Enrich each company's logo
+    Enum.each(companiesForLogoEnrichment, &enrich_company_logo/1)
+
+    # Log the batch processing result
+    if company_count > 0 do
+      Logger.info("Processed #{company_count} companies for logo enrichment")
+    end
+
+    # Schedule the next check
+    schedule_check(@default_interval_ms)
+
+    {:noreply, state}
+  end
+
+  # Schedule the next check
+  defp schedule_check(interval_ms) do
+    Process.send_after(self(), :enrich_companies, interval_ms)
+  end
+
+  defp enrich_company_logo(company) do
+    case Enrich.enrich_logo(company.id) do
+      :ok -> :ok
+      {:error, reason} ->
+        Logger.error("Failed to start logo enrichment for company: #{company.id} (domain: #{company.primary_domain}), reason: #{inspect(reason)}")
+    end
+  end
+end

--- a/lib/core/crm/companies/enrich.ex
+++ b/lib/core/crm/companies/enrich.ex
@@ -49,6 +49,36 @@ defmodule Core.Crm.Companies.Enrich do
 
   def enrich_logo(_), do: {:error, :invalid_company_id}
 
+  @doc """
+  Fetches companies that need logo enrichment.
+
+  ## Parameters
+    * `batch_size` - Number of records to return (default: 10)
+
+  ## Returns
+    * List of companies that:
+      - Have no logo_key
+      - Have not been attempted in the last 24 hours or have never been attempted
+  """
+  @spec fetch_companies_for_logo_enrichment(integer()) :: [Company.t()]
+  def fetch_companies_for_logo_enrichment(batch_size \\ 10) do
+    twenty_four_hours_ago = DateTime.add(DateTime.utc_now(), -24 * 60 * 60)
+    ten_minutes_ago = DateTime.add(DateTime.utc_now(), -10 * 60)
+    max_attempts = 5
+
+    Company
+    |> where([c], is_nil(c.logo_key) or c.logo_key == "")
+    |> where([c], c.logo_enrichment_attempts < ^max_attempts)
+    |> where(
+      [c],
+      is_nil(c.logo_enrich_attempt_at) or c.logo_enrich_attempt_at < ^twenty_four_hours_ago
+    )
+    |> where([c], c.inserted_at < ^ten_minutes_ago)
+    |> order_by([c], asc: c.logo_enrich_attempt_at)
+    |> limit(^batch_size)
+    |> Repo.all()
+  end
+
   # Server Callbacks
 
   @impl true
@@ -95,11 +125,13 @@ defmodule Core.Crm.Companies.Enrich do
 
       company ->
         if should_enrich_industry?(company) do
-          # Safely update only the industry_enrich_attempt_at field
           {count, _} =
             Repo.update_all(
               from(c in Company, where: c.id == ^company_id),
-              set: [industry_enrich_attempt_at: DateTime.utc_now()]
+              [
+                set: [industry_enrich_attempt_at: DateTime.utc_now()],
+                inc: [industry_enrichment_attempts: 1]
+              ]
             )
 
           if count > 0 do
@@ -159,11 +191,13 @@ defmodule Core.Crm.Companies.Enrich do
 
       company ->
         if should_enrich_name?(company) do
-          # Safely update only the name_enrich_attempt_at field
           {count, _} =
             Repo.update_all(
               from(c in Company, where: c.id == ^company_id),
-              set: [name_enrich_attempt_at: DateTime.utc_now()]
+              [
+                set: [name_enrich_attempt_at: DateTime.utc_now()],
+                inc: [name_enrichment_attempts: 1]
+              ]
             )
 
           if count > 0 do
@@ -211,11 +245,13 @@ defmodule Core.Crm.Companies.Enrich do
 
       company ->
         if should_enrich_country?(company) do
-          # Safely update only the country_enrich_attempt_at field
           {count, _} =
             Repo.update_all(
               from(c in Company, where: c.id == ^company_id),
-              set: [country_enrich_attempt_at: DateTime.utc_now()]
+              [
+                set: [country_enrich_attempt_at: DateTime.utc_now()],
+                inc: [country_enrichment_attempts: 1]
+              ]
             )
 
           if count > 0 do
@@ -266,11 +302,14 @@ defmodule Core.Crm.Companies.Enrich do
 
       company ->
         if should_enrich_logo?(company) do
-          # Safely update only the logo_enrich_attempt_at field
+          # Update both the attempt timestamp and increment attempts counter
           {count, _} =
             Repo.update_all(
               from(c in Company, where: c.id == ^company_id),
-              set: [logo_enrich_attempt_at: DateTime.utc_now()]
+              [
+                set: [logo_enrich_attempt_at: DateTime.utc_now()],
+                inc: [logo_enrichment_attempts: 1]
+              ]
             )
 
           if count > 0 do

--- a/priv/repo/migrations/20250526123535_add_enrichment_attempts_to_companies.exs
+++ b/priv/repo/migrations/20250526123535_add_enrichment_attempts_to_companies.exs
@@ -1,0 +1,18 @@
+defmodule Core.Repo.Migrations.AddEnrichmentAttemptsToCompanies do
+  use Ecto.Migration
+
+  def change do
+    alter table(:companies) do
+      add :logo_enrichment_attempts, :integer, default: 0, null: false
+      add :industry_enrichment_attempts, :integer, default: 0, null: false
+      add :name_enrichment_attempts, :integer, default: 0, null: false
+      add :country_enrichment_attempts, :integer, default: 0, null: false
+    end
+
+    # Create indexes for efficient querying of companies that need enrichment
+    create index(:companies, [:logo_enrichment_attempts, :logo_enrich_attempt_at])
+    create index(:companies, [:industry_enrichment_attempts, :industry_enrich_attempt_at])
+    create index(:companies, [:name_enrichment_attempts, :name_enrich_attempt_at])
+    create index(:companies, [:country_enrichment_attempts, :country_enrich_attempt_at])
+  end
+end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds enrichment attempt counters to companies, a GenServer for periodic enrichment, and updates the database schema.
> 
>   - **Behavior**:
>     - Adds enrichment attempt counters (`industry`, `name`, `country`, `logo`) to `Company` schema in `company.ex`.
>     - Introduces `CompanyEnricher` GenServer in `company_enricher.ex` for periodic logo enrichment every 15 minutes.
>     - Updates `Enrich` module in `enrich.ex` to increment attempt counters and handle enrichment logic.
>   - **Database**:
>     - Migration `20250526123535_add_enrichment_attempts_to_companies.exs` adds attempt counters to `companies` table and creates indexes for efficient querying.
>   - **Misc**:
>     - Updates `application.ex` to include `CompanyEnricher` in the supervision tree.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for a7025d68638af8d247235397648f78d5e60e54e8. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->