### PR TITLE
patch: create company for new tenant

### DIFF
--- a/lib/core/auth/tenants/tenant.ex
+++ b/lib/core/auth/tenants/tenant.ex
@@ -6,16 +6,19 @@ defmodule Core.Auth.Tenants.Tenant do
   schema "tenants" do
     field(:name, :string)
     field(:domain, :string)
+    field(:workspace_name, :string)
+    field(:workspace_icon_key, :string)
 
     timestamps(type: :utc_datetime)
   end
 
   def changeset(%__MODULE__{} = tenant, attrs) do
     tenant
-    |> cast(attrs, [:id, :name, :domain])
+    |> cast(attrs, [:id, :name, :domain, :workspace_name, :workspace_icon_key])
     |> maybe_put_id()
     |> validate_required([:id, :name, :domain])
     |> validate_length(:name, max: 160)
+    |> validate_length(:workspace_name, max: 160)
     |> unique_constraint(:name)
   end
 

--- a/priv/repo/migrations/20250527091001_add_workspace_fields_to_tenants.exs
+++ b/priv/repo/migrations/20250527091001_add_workspace_fields_to_tenants.exs
@@ -1,0 +1,10 @@
+defmodule Core.Repo.Migrations.AddWorkspaceFieldsToTenants do
+  use Ecto.Migration
+
+  def change do
+    alter table(:tenants) do
+      add :workspace_name, :string
+      add :workspace_icon_key, :string
+    end
+  end
+end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds company creation for new tenants and updates tenant schema with workspace fields.
> 
>   - **Behavior**:
>     - Adds `process_company_for_tenant/1` in `tenants.ex` to create a company for a new tenant and update `workspace_name`.
>     - Adds `set_tenant_workspace_name/2` to update tenant's `workspace_name`.
>     - Moves Slack notification logic to `notify_slack_new_tenant/1`.
>   - **Schema Changes**:
>     - Adds `workspace_name` and `workspace_icon_key` fields to `Tenant` schema in `tenant.ex`.
>     - Updates `changeset/2` in `tenant.ex` to handle new fields.
>   - **Migrations**:
>     - New migration `20250527091001_add_workspace_fields_to_tenants.exs` to add `workspace_name` and `workspace_icon_key` to `tenants` table.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for b20bab05c1790f3293161895bb069a87ac0a20ff. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->