### PR TITLE
Trace 2

### DIFF
--- a/lib/core/crm/companies.ex
+++ b/lib/core/crm/companies.ex
@@ -46,7 +46,7 @@ defmodule Core.Crm.Companies do
         OpenTelemetry.Tracer.set_status(:ok)
         {:ok, company}
       else
-        {:error, reason} = error ->
+        {:error, _reason} = error ->
           OpenTelemetry.Tracer.set_status(:error, "creation_failed")
           error
       end
@@ -72,10 +72,15 @@ defmodule Core.Crm.Companies do
       case result do
         {:ok, company} ->
           OpenTelemetry.Tracer.set_status(:ok)
-          result
-        {:error, changeset} ->
+          {:ok, company}
+
+        {:error, _changeset} ->
+          OpenTelemetry.Tracer.set_attributes([
+            {"result.success", false},
+            {"error.type", "validation_failed"}
+          ])
           OpenTelemetry.Tracer.set_status(:error, "validation_failed")
-          result
+          {:error, :validation_failed}
       end
     end
   end

--- a/lib/core/web_tracker/schemas/web_session.ex
+++ b/lib/core/web_tracker/schemas/web_session.ex
@@ -19,6 +19,7 @@ defmodule Core.WebTracker.Schemas.WebSession do
     field :origin, :string
     field :active, :boolean, default: true
     field :metadata, :map, default: %{}
+    field :just_created, :boolean, virtual: true, default: false
 
     # IP information
     field :ip, :string
@@ -43,6 +44,7 @@ defmodule Core.WebTracker.Schemas.WebSession do
     origin: String.t(),
     active: boolean(),
     metadata: map(),
+    just_created: boolean(),
     # IP information
     ip: String.t() | nil,
     city: String.t() | nil,
@@ -69,7 +71,7 @@ defmodule Core.WebTracker.Schemas.WebSession do
   def changeset(session, attrs) do
     session
     |> cast(attrs, [
-      :id, :tenant, :visitor_id, :origin, :active, :metadata,
+      :id, :tenant, :visitor_id, :origin, :active, :metadata, :just_created,
       :ip, :city, :region, :country_code, :is_mobile,
       :started_at, :ended_at, :last_event_at, :last_event_type
     ])

--- a/lib/core/web_tracker/web_tracker.ex
+++ b/lib/core/web_tracker/web_tracker.ex
@@ -128,7 +128,7 @@ defmodule Core.WebTracker do
   end
 
   defp validate_ip_safety(attrs) do
-    OpenTelemetry.Tracer.with_span "web_tracker.validate_ip" do
+    OpenTelemetry.Tracer.with_span "web_tracker.validate_ip_safety" do
       OpenTelemetry.Tracer.set_attributes([{"ip", attrs.ip}])
 
       ip_intelligence_mod = get_ip_intelligence_module()
@@ -154,7 +154,7 @@ defmodule Core.WebTracker do
   defp create_session_with_ip_data({:error, _, _} = error), do: error
 
   defp create_session_with_ip_data({:ok, attrs, ip_data}) do
-    OpenTelemetry.Tracer.with_span "web_tracker.create_session" do
+    OpenTelemetry.Tracer.with_span "web_tracker.create_session_with_ip_data" do
       session_attrs = %{
         tenant: attrs.tenant,
         visitor_id: attrs.visitor_id,
@@ -201,7 +201,7 @@ defmodule Core.WebTracker do
   defp enrich_with_company_data({:error, _, _} = error), do: error
 
   defp enrich_with_company_data({:ok, attrs, session, :event_created}) do
-    OpenTelemetry.Tracer.with_span "web_tracker.enrich_company_data" do
+    OpenTelemetry.Tracer.with_span "web_tracker.enrich_with_company_data" do
       # Only enrich for new sessions (not existing ones)
       if session.inserted_at == session.updated_at do
         OpenTelemetry.Tracer.set_attributes([{"enrichment.type", "new_session"}])


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Integrate OpenTelemetry tracing across API logging, CRM, and web tracking modules, and add a `just_created` field to web sessions.
> 
>   - **OpenTelemetry Tracing**:
>     - Added tracing to `request()` in `logger.ex` for API calls, including span creation and attribute setting.
>     - Integrated tracing in `get_or_create_by_domain()` and `create_with_domain()` in `companies.ex`.
>     - Enhanced tracing in `process_new_event()` and related functions in `web_tracker.ex`.
>   - **Schema Changes**:
>     - Added `just_created` virtual field to `WebSession` schema in `web_session.ex`.
>   - **Functionality**:
>     - Updated `get_or_create_session()` in `web_tracker.ex` to use `just_created` flag for session enrichment.
>     - Refactored error handling in `create_with_domain()` in `companies.ex` to return `:validation_failed`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for edbeaf5250e5a4afd8448d5a9f3c040dd2680d95. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->