### PR TITLE
patch: trace aws request

### DIFF
--- a/lib/core/crm/companies/company_enricher.ex
+++ b/lib/core/crm/companies/company_enricher.ex
@@ -66,10 +66,7 @@ defmodule Core.Crm.Companies.CompanyEnricher do
           :ok
 
         {:error, reason} ->
-          OpenTelemetry.Tracer.set_status(:error, "enrichment_failed")
-          OpenTelemetry.Tracer.set_attributes([
-            {"error.reason", inspect(reason)}
-          ])
+          OpenTelemetry.Tracer.set_status(:error, inspect(reason))
           Logger.error("Failed to start icon enrichment for company: #{company.id} (domain: #{company.primary_domain}), reason: #{inspect(reason)}")
           {:error, reason}
       end

--- a/lib/core/utils/http_client/aws_http_client.ex
+++ b/lib/core/utils/http_client/aws_http_client.ex
@@ -7,22 +7,28 @@ defmodule Core.Utils.HttpClient.AwsHttpClient do
   @behaviour ExAws.Request.HttpClient
 
   require Logger
+  require OpenTelemetry.Tracer
 
   @impl true
   def request(method, url, body, headers, http_opts) do
-    case http_opts do
-      [] -> :noop
-      opts -> Logger.debug("ExAws HTTP options: #{inspect(opts)}")
-    end
+    OpenTelemetry.Tracer.with_span "aws_http_client.request" do
+      case http_opts do
+        [] -> :noop
+        opts -> Logger.debug("ExAws HTTP options: #{inspect(opts)}")
+      end
 
-    with {:ok, resp} <-
-           Finch.build(method, url, headers, body)
-           |> Finch.request(Core.Finch) do
-      {:ok, %{status_code: resp.status, body: resp.body, headers: resp.headers}}
-    else
-      {:error, reason} ->
-        Logger.error("ExAws HTTP request failed: #{inspect(reason)}")
-        {:error, %{reason: reason}}
+      with {:ok, resp} <-
+             Finch.build(method, url, headers, body)
+             |> Finch.request(Core.Finch) do
+        OpenTelemetry.Tracer.set_status(:ok)
+        {:ok,
+         %{status_code: resp.status, body: resp.body, headers: resp.headers}}
+      else
+        {:error, reason} ->
+          Logger.error("ExAws HTTP request failed: #{inspect(reason)}")
+          OpenTelemetry.Tracer.set_status(:error, inspect(reason))
+          {:error, %{reason: reason}}
+      end
     end
   end
 end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add OpenTelemetry tracing to AWS HTTP requests and modify error handling in company enrichment.
> 
>   - **Tracing**:
>     - Add `OpenTelemetry.Tracer.with_span` to `request()` in `aws_http_client.ex` for tracing AWS HTTP requests.
>     - Add `OpenTelemetry.Tracer.set_status` for success and error cases in `aws_http_client.ex`.
>   - **Error Handling**:
>     - Modify `set_status` in `company_enricher.ex` to include error reason directly in the status.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for ff0c252b9c869acf7412111e44c36b17986a0f1d. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->