### PR TITLE
patch: optional web session closer

### DIFF
--- a/lib/core/crm/companies/company_domain_processor.ex
+++ b/lib/core/crm/companies/company_domain_processor.ex
@@ -24,9 +24,9 @@ defmodule Core.Crm.Companies.CompanyDomainProcessor do
   @default_batch_size 10
 
   def start_link(opts \\ []) do
-    enabled = Application.get_env(:core, :crons)[:enabled] || false
+    crons_enabled = Application.get_env(:core, :crons)[:enabled] || false
 
-    if enabled do
+    if crons_enabled do
       GenServer.start_link(__MODULE__, opts, name: __MODULE__)
     else
       Logger.info("Company domain processor is disabled (crons disabled)")

--- a/lib/core/crm/companies/company_enricher.ex
+++ b/lib/core/crm/companies/company_enricher.ex
@@ -28,9 +28,9 @@ defmodule Core.Crm.Companies.CompanyEnricher do
   @default_batch_size 10
 
   def start_link(opts \\ []) do
-    enabled = Application.get_env(:core, :crons)[:enabled] || false
+    crons_enabled = Application.get_env(:core, :crons)[:enabled] || false
 
-    if enabled do
+    if crons_enabled do
       GenServer.start_link(__MODULE__, opts, name: __MODULE__)
     else
       Logger.info("Company enricher is disabled (crons disabled)")


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add conditional GenServer start based on cron configuration in `CompanyDomainProcessor`, `CompanyEnricher`, and `WebSessionCloser`.
> 
>   - **Behavior**:
>     - `start_link` functions in `CompanyDomainProcessor`, `CompanyEnricher`, and `WebSessionCloser` now check `:core, :crons, :enabled` config before starting GenServer.
>     - If crons are disabled, log a message and return `:ignore`.
>   - **Code Quality**:
>     - Renamed `enabled` to `crons_enabled` in `CompanyDomainProcessor` and `CompanyEnricher` for clarity.
>     - Minor formatting improvements in `WebSessionCloser` for better readability.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for a958e614059744f74da49bcd6ab1cf70f5dcc982. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->