### PR TITLE
patch: normalize origin

### DIFF
--- a/lib/core/web_tracker/origin_tenant_mapper.ex
+++ b/lib/core/web_tracker/origin_tenant_mapper.ex
@@ -31,9 +31,11 @@ defmodule Core.WebTracker.OriginTenantMapper do
   @spec normalize_origin(String.t()) :: String.t()
   defp normalize_origin(origin) do
     origin
-    |> String.replace(~r/^https?:\/\//, "")
     |> String.trim()
-    |> String.trim_trailing("/")
+    |> String.downcase()
+    |> String.replace(~r/^https?:\/\//, "") # Remove http:// or https://
+    |> String.replace(~r/^www\./, "") # Remove www.
+    |> String.trim_trailing("/") # Remove trailing slash
   end
 
   @doc """


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhances `normalize_origin` in `origin_tenant_mapper.ex` to standardize origin format by removing prefixes and converting to lowercase.
> 
>   - **Normalization**:
>     - `normalize_origin` in `origin_tenant_mapper.ex` now converts origin to lowercase.
>     - Removes `http://`, `https://`, and `www.` prefixes.
>     - Trims trailing slashes from the origin.
>   - **Behavior**:
>     - Ensures consistent origin format for whitelist checks in `get_tenant_for_origin` and `whitelisted?`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for 42729614575e133102b90db5d380f5c6f100a9f6. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->