### PR TITLE
patch: primary domain check not to report error on non-primary domain

### DIFF
--- a/lib/core/crm/companies/company_enrich.ex
+++ b/lib/core/crm/companies/company_enrich.ex
@@ -110,7 +110,7 @@ defmodule Core.Crm.Companies.CompanyEnrich do
                     "Failed to scrape homepage for company #{company_id} (domain: #{company.primary_domain}): #{inspect(reason)}"
                   )
 
-                  Tracing.error(inspect(reason))
+                  Tracing.error(reason)
 
                   {:error, reason}
               end
@@ -321,7 +321,7 @@ defmodule Core.Crm.Companies.CompanyEnrich do
                     "Failed to get name from AI for company #{company_id} (domain: #{company.primary_domain}): #{inspect(reason)}"
                   )
 
-                  Tracing.error(inspect(reason))
+                  Tracing.error(reason)
 
                   {:error, reason}
               end
@@ -419,7 +419,7 @@ defmodule Core.Crm.Companies.CompanyEnrich do
                     "Failed to get country code from AI for company #{company_id} (domain: #{company.primary_domain}): #{inspect(reason)}"
                   )
 
-                  Tracing.error(inspect(reason))
+                  Tracing.error(reason)
 
                   {:error, reason}
               end
@@ -519,7 +519,7 @@ defmodule Core.Crm.Companies.CompanyEnrich do
                       end
 
                     {:error, reason} ->
-                      Tracing.error(inspect(reason))
+                      Tracing.error(reason)
 
                       Logger.error(
                         "Failed to store icon for company #{company_id} (domain: #{company.primary_domain}): #{inspect(reason)}"
@@ -529,7 +529,7 @@ defmodule Core.Crm.Companies.CompanyEnrich do
                   end
 
                 {:error, reason} ->
-                  Tracing.error(inspect(reason))
+                  Tracing.error(reason)
 
                   Logger.error(
                     "Failed to download icon for company #{company_id} (domain: #{company.primary_domain}): #{inspect(reason)}"

--- a/lib/core/crm/companies/company_enricher.ex
+++ b/lib/core/crm/companies/company_enricher.ex
@@ -105,7 +105,7 @@ defmodule Core.Crm.Companies.CompanyEnricher do
           :ok
 
         {:error, reason} ->
-          Tracing.error(inspect(reason))
+          Tracing.error(reason)
 
           Logger.error(
             "Failed to start icon enrichment for company: #{company.id} (domain: #{company.primary_domain}), reason: #{inspect(reason)}"
@@ -165,7 +165,7 @@ defmodule Core.Crm.Companies.CompanyEnricher do
           :ok
 
         {:error, reason} ->
-          Tracing.error(inspect(reason))
+          Tracing.error(reason)
 
           {:error, reason}
       end
@@ -221,7 +221,7 @@ defmodule Core.Crm.Companies.CompanyEnricher do
           :ok
 
         {:error, reason} ->
-          Tracing.error(inspect(reason))
+          Tracing.error(reason)
 
           {:error, reason}
       end
@@ -277,7 +277,7 @@ defmodule Core.Crm.Companies.CompanyEnricher do
           :ok
 
         {:error, reason} ->
-          Tracing.error(inspect(reason))
+          Tracing.error(reason)
 
           {:error, reason}
       end

--- a/lib/core/utils/http_client/aws_http_client.ex
+++ b/lib/core/utils/http_client/aws_http_client.ex
@@ -27,7 +27,7 @@ defmodule Core.Utils.HttpClient.AwsHttpClient do
       else
         {:error, reason} ->
           Logger.error("ExAws HTTP request failed: #{inspect(reason)}")
-          Tracing.error(inspect(reason))
+          Tracing.error(reason)
           {:error, %{reason: reason}}
       end
     end

--- a/lib/core/utils/tracing.ex
+++ b/lib/core/utils/tracing.ex
@@ -18,10 +18,11 @@ defmodule Core.Utils.Tracing do
         :ok
 
       _ctx ->
-        set_status(:error, inspect(reason))
+        reason_str = to_reason_string(reason)
+        set_status(:error, reason_str)
 
         set_attributes([
-          {"error.reason", inspect(reason)}
+          {"error.reason", reason_str}
         ])
     end
   end
@@ -33,6 +34,15 @@ defmodule Core.Utils.Tracing do
 
       _ctx ->
         set_status(:ok)
+    end
+  end
+
+  def to_reason_string(reason) do
+    try do
+      to_string(reason)
+    rescue
+      Protocol.UndefinedError ->
+        inspect(reason)
     end
   end
 end

--- a/lib/core/web_tracker/web_tracker.ex
+++ b/lib/core/web_tracker/web_tracker.ex
@@ -52,7 +52,7 @@ defmodule Core.WebTracker do
           result
 
         {:error, :bad_request, reason} = result ->
-          Tracing.error(inspect(reason))
+          Tracing.error(reason)
           result
       end
     end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Improve error handling and domain checking by refining `Tracing.error` usage and enhancing primary domain logic.
> 
>   - **Error Handling**:
>     - Change `Tracing.error(inspect(reason))` to `Tracing.error(reason)` in `company_enrich.ex`, `company_enricher.ex`, `aws_http_client.ex`, `web_tracker.ex`.
>     - Add `to_reason_string/1` in `tracing.ex` to convert reasons to strings safely.
>   - **Domain Handling**:
>     - Modify `get_primary_domain/1` in `primary_domain_finder.ex` to handle non-primary domains without error.
>     - Add detailed tracing attributes for domain results in `primary_domain_finder.ex`.
>   - **Misc**:
>     - Minor logging improvements in `aws_http_client.ex` and `web_tracker.ex`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for 7db58a93128f990c6dbf0c9de28b73f4d6500dd4. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->