### PR TITLE
patch: do not report trace error if icon not found

### DIFF
--- a/lib/core/crm/companies/company_enrich.ex
+++ b/lib/core/crm/companies/company_enrich.ex
@@ -533,11 +533,11 @@ defmodule Core.Crm.Companies.CompanyEnrich do
                     {"result.cause", :image_not_found}
                   ])
 
-                  Logger.warn(
+                  Logger.warning(
                     "Icon not found for company #{company_id} (domain: #{company.primary_domain})"
                   )
 
-                  {:error, reason}
+                  {:error, :image_not_found}
 
                 {:error, reason} ->
                   Tracing.error(reason)

--- a/lib/core/utils/media/images.ex
+++ b/lib/core/utils/media/images.ex
@@ -50,7 +50,7 @@ defmodule Core.Utils.Media.Images do
   Downloads an image from a URL.
   Returns {:ok, binary_data} or {:error, reason}
   """
-  @spec download_image(String.t()) :: {:ok, binary()} | {:error, :image_not_found} | {:error, term()}
+  @spec download_image(String.t()) :: {:ok, binary()} | {:error, :image_not_found} | {:error, String.t()}
   def download_image(url) do
     case Finch.build(:get, url, [], []) |> Finch.request(Core.Finch) do
       {:ok, %{status: 200, body: body}} ->


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Improve error handling for missing icons in `company_enrich.ex` by logging warnings instead of trace errors and update `download_image/1` spec in `images.ex`.
> 
>   - **Behavior**:
>     - In `company_enrich.ex`, when an icon is not found, log a warning instead of reporting a trace error.
>     - Update `brandfetch_url` construction to remove `/type` from the path.
>   - **Error Handling**:
>     - In `images.ex`, update `download_image/1` spec to return `{:error, String.t()}` for non-404 errors.
>   - **Misc**:
>     - Minor refactoring in `company_enrich.ex` to rename `client_id` to `brandfetch_client_id`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for b7933cf531172599fc09ae64248b602708c4ffd3. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->