### PR TITLE
patch: crash alerts in slack

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -6,7 +6,8 @@ config :core,
   generators: [timestamp_type: :utc_datetime]
 
 # OpenTelemetry configuration for SigNoz
-config :opentelemetry, :resource, service: %{name: System.get_env("OTEL_SERVICE_NAME", "customeros-core")}
+config :opentelemetry, :resource,
+  service: %{name: System.get_env("OTEL_SERVICE_NAME", "customeros-core")}
 
 config :opentelemetry, :processors,
   otel_batch_processor: %{
@@ -79,8 +80,10 @@ config :inertia,
   raise_on_ssr_failure: true
 
 # Cron jobs configuration
-config :core, :crons,
-  enabled: true
+config :core, :crons, enabled: true
+
+config :logger,
+  backends: [Core.Notifications.CrashMonitor, :console]
 
 # Import environment specific config
 import_config "#{config_env()}.exs"

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -138,4 +138,5 @@ config :core, :brandfetch, client_id: get_env.("BRANDFETCH_CLIENT_ID", nil)
 # Slack configuration
 config :core, :slack,
   new_tenant_webhook_url: get_env.("SLACK_NEW_TENANT_WEBHOOK_URL", nil),
-  new_user_webhook_url: get_env.("SLACK_NEW_USER_WEBHOOK_URL", nil)
+  new_user_webhook_url: get_env.("SLACK_NEW_USER_WEBHOOK_URL", nil),
+  crash_webhook_url: get_env.("SLACK_CRASH_WEBHOOK_URL", nil)

--- a/lib/application.ex
+++ b/lib/application.ex
@@ -6,6 +6,7 @@ defmodule Core.Application do
   def start(_type, _args) do
     OpentelemetryPhoenix.setup(adapter: :bandit)
     OpentelemetryEcto.setup([:core, :repo], db_statement: :enabled)
+    Logger.add_backend(Core.Notifications.CrashMonitor)
 
     children = [
       {Phoenix.PubSub, name: Core.PubSub},

--- a/lib/core/notifications/crash_monitor.ex
+++ b/lib/core/notifications/crash_monitor.ex
@@ -1,0 +1,245 @@
+defmodule Core.Notifications.CrashMonitor do
+  @moduledoc """
+  Logger backend that captures crashes and sends them to Slack.
+  Includes rate limiting and error prevention to avoid notification loops.
+  """
+
+  @behaviour :gen_event
+  alias Core.Notifications.Slack
+  require Logger
+
+  # Rate limiting: max 5 alerts per 5 minutes
+  @max_alerts_per_window 5
+  @rate_limit_window_seconds 300
+
+  def init(_opts) do
+    {:ok,
+     %{
+       alerts_sent: [],
+       total_crashes: 0
+     }}
+  end
+
+  def handle_call({:configure, _opts}, state) do
+    {:ok, :ok, state}
+  end
+
+  def handle_event({level, _gl, {Logger, msg, _timestamp, metadata}}, state)
+      when level in [:error] do
+    if is_crash_report?(msg) and should_send_alert?(state) do
+      # Send alert in background to avoid blocking logging
+      Task.start(fn ->
+        send_crash_notification(msg, metadata)
+      end)
+
+      # Update state with new alert timestamp
+      new_state = update_alert_state(state)
+      {:ok, new_state}
+    else
+      {:ok, %{state | total_crashes: state.total_crashes + 1}}
+    end
+  end
+
+  def handle_event(_event, state) do
+    {:ok, state}
+  end
+
+  def handle_info(_msg, state) do
+    {:ok, state}
+  end
+
+  def terminate(_reason, _state) do
+    :ok
+  end
+
+  def code_change(_old_vsn, state, _extra) do
+    {:ok, state}
+  end
+
+  # Detect if this is actually a crash report
+  defp is_crash_report?(msg) do
+    msg_str = to_string(msg)
+
+    # Look for common crash indicators
+    crash_indicators = [
+      "GenServer",
+      "Task",
+      "Process",
+      "crashed",
+      "terminated",
+      "** (exit)",
+      "** (throw)",
+      "** (error)",
+      "** (ArithmeticError)",
+      "** (RuntimeError)",
+      "** (MatchError)",
+      "** (FunctionClauseError)",
+      "EXIT"
+    ]
+
+    # Must contain crash indicator AND not be our own notifications
+    Enum.any?(crash_indicators, &String.contains?(msg_str, &1)) and
+      not slack_notification_error?(msg_str)
+  end
+
+  # Prevent infinite loops from our own Slack notification failures
+  defp slack_notification_error?(msg_str) do
+    String.contains?(msg_str, [
+      "Finch",
+      "HTTPoison",
+      "Slack",
+      "webhook",
+      "Core.Notifications"
+    ])
+  end
+
+  # Rate limiting logic
+  defp should_send_alert?(state) do
+    now = System.system_time(:second)
+
+    # Remove old alerts outside the window
+    recent_alerts =
+      Enum.filter(state.alerts_sent, fn timestamp ->
+        now - timestamp < @rate_limit_window_seconds
+      end)
+
+    # Check if we're under the limit
+    length(recent_alerts) < @max_alerts_per_window
+  end
+
+  defp update_alert_state(state) do
+    now = System.system_time(:second)
+
+    # Add current timestamp and clean old ones
+    new_alerts =
+      [now | state.alerts_sent]
+      |> Enum.filter(fn timestamp ->
+        now - timestamp < @rate_limit_window_seconds
+      end)
+
+    %{state | alerts_sent: new_alerts, total_crashes: state.total_crashes + 1}
+  end
+
+  defp send_crash_notification(msg, metadata) do
+    try do
+      # Extract useful information
+      error_type = extract_error_type(msg)
+      error_message = format_error_message(msg)
+      location = extract_location(metadata, msg)
+      stacktrace = extract_stacktrace(msg)
+
+      # Send to Slack
+      case Slack.notify_crash(error_type, error_message, location, stacktrace) do
+        :ok ->
+          :ok
+
+        {:error, reason} ->
+          # Log but don't crash - we don't want notification failures to cause more crashes
+          Logger.warning(
+            "Failed to send crash notification to Slack: #{inspect(reason)}"
+          )
+      end
+    rescue
+      error ->
+        # Absolutely prevent notification errors from causing more notifications
+        Logger.warning("Error in crash notification system: #{inspect(error)}")
+    end
+  end
+
+  defp extract_error_type(msg) do
+    msg_str = to_string(msg)
+
+    cond do
+      String.contains?(msg_str, "GenServer") ->
+        "GenServer Crash"
+
+      String.contains?(msg_str, "Task") ->
+        "Task Crash"
+
+      String.contains?(msg_str, "** (") ->
+        # Extract exception type from ** (ExceptionType) format
+        case Regex.run(~r/\*\* \(([^)]+)\)/, msg_str) do
+          [_, exception_type] -> exception_type
+          _ -> "Exception"
+        end
+
+      true ->
+        "Process Exit"
+    end
+  end
+
+  defp format_error_message(msg) do
+    msg_str = to_string(msg)
+
+    # Try to extract the actual error message, not the full crash report
+    cond do
+      String.contains?(msg_str, "** (") ->
+        # Extract message after exception type
+        case Regex.run(~r/\*\* \([^)]+\) (.+)/, msg_str) do
+          [_, error_msg] ->
+            error_msg
+            |> String.split("\n")
+            |> List.first()
+            |> String.slice(0, 200)
+
+          _ ->
+            String.slice(msg_str, 0, 200)
+        end
+
+      true ->
+        # Just take first line and truncate
+        msg_str
+        |> String.split("\n")
+        |> List.first()
+        |> String.slice(0, 200)
+    end
+  end
+
+  defp extract_location(metadata, msg) do
+    cond do
+      # Try to get from metadata first (most reliable)
+      metadata[:mfa] ->
+        {mod, fun, arity} = metadata[:mfa]
+        "#{mod}.#{fun}/#{arity}"
+
+      metadata[:module] ->
+        "#{metadata[:module]}"
+
+      # Try to extract from crash report
+      true ->
+        msg_str = to_string(msg)
+
+        case Regex.run(~r/\(([A-Z][A-Za-z0-9.]+)\)/, msg_str) do
+          [_, module] -> module
+          _ -> nil
+        end
+    end
+  end
+
+  defp extract_stacktrace(msg) do
+    msg_str = to_string(msg)
+
+    # Look for stacktrace in the message
+    if String.contains?(msg_str, "stacktrace") or
+         String.contains?(msg_str, "    (") do
+      # Try to extract just the stacktrace part
+      lines = String.split(msg_str, "\n")
+
+      stacktrace_lines =
+        lines
+        |> Enum.drop_while(fn line ->
+          not String.contains?(line, ["stacktrace", "    ("])
+        end)
+        # Limit to first 10 lines of stacktrace
+        |> Enum.take(10)
+
+      if length(stacktrace_lines) > 0 do
+        Enum.join(stacktrace_lines, "\n")
+      else
+        nil
+      end
+    else
+      nil
+    end
+  end
+end

--- a/lib/core/notifications/slack.ex
+++ b/lib/core/notifications/slack.ex
@@ -10,9 +10,17 @@ defmodule Core.Notifications.Slack do
   Generic function to send a message to Slack.
   Returns :ok on success or {:error, reason} on failure.
   """
-  @spec send_message(String.t(), map()) :: :ok | {:error, :slack_api_error | Finch.Error.t()}
-  def send_message(webhook_url, message) when is_binary(webhook_url) and is_map(message) do
-    case Finch.request(Core.Finch, :post, webhook_url, [{"Content-Type", "application/json"}], Jason.encode!(message)) do
+  @spec send_message(String.t(), map()) ::
+          :ok | {:error, :slack_api_error | Finch.Error.t()}
+  def send_message(webhook_url, message)
+      when is_binary(webhook_url) and is_map(message) do
+    case Finch.request(
+           Core.Finch,
+           :post,
+           webhook_url,
+           [{"Content-Type", "application/json"}],
+           Jason.encode!(message)
+         ) do
       {:ok, %{status: 200}} ->
         :ok
 
@@ -30,8 +38,12 @@ defmodule Core.Notifications.Slack do
   Send a notification about a new tenant registration.
   Includes tenant name, domain, and registration timestamp.
   """
-  @spec notify_new_tenant(String.t(), String.t()) :: :ok | {:error, :webhook_not_configured | :slack_api_error | Finch.Error.t()}
-  def notify_new_tenant(name, domain) when is_binary(name) and is_binary(domain) and name != "" and domain != "" do
+  @spec notify_new_tenant(String.t(), String.t()) ::
+          :ok
+          | {:error,
+             :webhook_not_configured | :slack_api_error | Finch.Error.t()}
+  def notify_new_tenant(name, domain)
+      when is_binary(name) and is_binary(domain) and name != "" and domain != "" do
     webhook_url = Application.get_env(:core, :slack)[:new_tenant_webhook_url]
 
     unless webhook_url do
@@ -66,7 +78,8 @@ defmodule Core.Notifications.Slack do
             elements: [
               %{
                 type: "mrkdwn",
-                text: "Registered at: #{DateTime.utc_now() |> Calendar.strftime("%Y-%m-%d %H:%M:%S UTC")}"
+                text:
+                  "Registered at: #{DateTime.utc_now() |> Calendar.strftime("%Y-%m-%d %H:%M:%S UTC")}"
               }
             ]
           }
@@ -76,14 +89,20 @@ defmodule Core.Notifications.Slack do
       send_message(webhook_url, message)
     end
   end
+
   def notify_new_tenant(_, _), do: {:error, :invalid_input}
 
   @doc """
   Send a notification about a new user registration.
   Includes user email, tenant name, and registration timestamp.
   """
-  @spec notify_new_user(String.t(), String.t()) :: :ok | {:error, :webhook_not_configured | :slack_api_error | Finch.Error.t()}
-  def notify_new_user(email, tenant) when is_binary(email) and is_binary(tenant) and email != "" and tenant != "" do
+  @spec notify_new_user(String.t(), String.t()) ::
+          :ok
+          | {:error,
+             :webhook_not_configured | :slack_api_error | Finch.Error.t()}
+  def notify_new_user(email, tenant)
+      when is_binary(email) and is_binary(tenant) and email != "" and
+             tenant != "" do
     webhook_url = Application.get_env(:core, :slack)[:new_user_webhook_url]
 
     unless webhook_url do
@@ -110,7 +129,7 @@ defmodule Core.Notifications.Slack do
               %{
                 type: "mrkdwn",
                 text: "*Tenant:*\n#{tenant}"
-              },
+              }
             ]
           },
           %{
@@ -118,7 +137,8 @@ defmodule Core.Notifications.Slack do
             elements: [
               %{
                 type: "mrkdwn",
-                text: "Registered at: #{DateTime.utc_now() |> Calendar.strftime("%Y-%m-%d %H:%M:%S UTC")}"
+                text:
+                  "Registered at: #{DateTime.utc_now() |> Calendar.strftime("%Y-%m-%d %H:%M:%S UTC")}"
               }
             ]
           }
@@ -128,5 +148,110 @@ defmodule Core.Notifications.Slack do
       send_message(webhook_url, message)
     end
   end
+
   def notify_new_user(_, _), do: {:error, :invalid_input}
+
+  @doc """
+  Send a notification about a system crash or error.
+  Includes error type, message, module/function context, and timestamp.
+  """
+  @spec notify_crash(String.t(), String.t(), String.t() | nil, String.t() | nil) ::
+          :ok
+          | {:error,
+             :webhook_not_configured | :slack_api_error | Finch.Error.t()}
+  def notify_crash(
+        error_type,
+        error_message,
+        module_function \\ nil,
+        stacktrace \\ nil
+      )
+      when is_binary(error_type) and is_binary(error_message) and
+             error_type != "" and error_message != "" do
+    webhook_url = Application.get_env(:core, :slack)[:crash_webhook_url]
+
+    unless webhook_url do
+      Logger.warning("Slack crash webhook URL not configured")
+      {:error, :webhook_not_configured}
+    else
+      # Build the fields array
+      fields = [
+        %{
+          type: "mrkdwn",
+          text: "*Error Type:*\n`#{error_type}`"
+        },
+        %{
+          type: "mrkdwn",
+          text:
+            "*Message:*\n```#{String.slice(error_message, 0, 200)}#{if String.length(error_message) > 200, do: "...", else: ""}```"
+        }
+      ]
+
+      # Add module/function if provided
+      fields =
+        if module_function do
+          fields ++
+            [
+              %{
+                type: "mrkdwn",
+                text: "*Location:*\n`#{module_function}`"
+              }
+            ]
+        else
+          fields
+        end
+
+      # Build the blocks
+      blocks = [
+        %{
+          type: "header",
+          text: %{
+            type: "plain_text",
+            text: "🚨 System Crash Detected",
+            emoji: true
+          }
+        },
+        %{
+          type: "section",
+          fields: fields
+        },
+        %{
+          type: "context",
+          elements: [
+            %{
+              type: "mrkdwn",
+              text:
+                "Occurred at: #{DateTime.utc_now() |> Calendar.strftime("%Y-%m-%d %H:%M:%S UTC")}"
+            }
+          ]
+        }
+      ]
+
+      # Add stacktrace section if provided
+      blocks =
+        if stacktrace && stacktrace != "" do
+          stacktrace_preview = String.slice(stacktrace, 0, 500)
+
+          stacktrace_text =
+            if String.length(stacktrace) > 500,
+              do: stacktrace_preview <> "...",
+              else: stacktrace_preview
+
+          blocks ++
+            [
+              %{
+                type: "section",
+                text: %{
+                  type: "mrkdwn",
+                  text: "*Stacktrace:*\n```#{stacktrace_text}```"
+                }
+              }
+            ]
+        else
+          blocks
+        end
+
+      message = %{blocks: blocks}
+      send_message(webhook_url, message)
+    end
+  end
 end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add crash alert notifications to Slack with rate limiting using a new logger backend `Core.Notifications.CrashMonitor`.
> 
>   - **Feature**:
>     - Add `Core.Notifications.CrashMonitor` to capture crashes and send alerts to Slack with rate limiting (max 5 alerts per 5 minutes).
>     - Add `notify_crash/4` function in `Slack` module to format and send crash notifications.
>   - **Configuration**:
>     - Add `Core.Notifications.CrashMonitor` to logger backends in `config.exs`.
>     - Add `crash_webhook_url` to Slack configuration in `runtime.exs`.
>   - **Application**:
>     - Add `Core.Notifications.CrashMonitor` as a logger backend in `Core.Application`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for 5572697cdd931b02d4063b629f589063befc22ca. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->