### PR TITLE
patch: fix slack crash notifications

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -9,13 +9,19 @@ config :core,
 config :opentelemetry, :resource,
   service: %{name: System.get_env("OTEL_SERVICE_NAME", "customeros-core")}
 
-config :opentelemetry, :processors,
-  otel_batch_processor: %{
-    exporter: {
-      :opentelemetry_exporter,
-      %{endpoints: [System.get_env("OTEL_EXPORTER_OTLP_ENDPOINT")]}
-    }
-  }
+config :opentelemetry,
+       :processors,
+       if(System.get_env("OTEL_EXPORTER_OTLP_ENDPOINT"),
+         do: [
+           otel_batch_processor: %{
+             exporter: {
+               :opentelemetry_exporter,
+               %{endpoints: [System.get_env("OTEL_EXPORTER_OTLP_ENDPOINT")]}
+             }
+           }
+         ],
+         else: []
+       )
 
 # Web endpoint
 config :core, Web.Endpoint,

--- a/lib/core/notifications/crash_monitor.ex
+++ b/lib/core/notifications/crash_monitor.ex
@@ -86,7 +86,6 @@ defmodule Core.Notifications.CrashMonitor do
   defp slack_notification_error?(msg_str) do
     String.contains?(msg_str, [
       "Finch",
-      "HTTPoison",
       "Slack",
       "webhook",
       "Core.Notifications"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes Slack crash notifications by updating OpenTelemetry configuration and refining crash detection logic in `CrashMonitor`.
> 
>   - **OpenTelemetry Configuration**:
>     - Updates `config.exs` to conditionally configure `otel_batch_processor` only if `OTEL_EXPORTER_OTLP_ENDPOINT` is set.
>   - **Crash Detection**:
>     - Removes "HTTPoison" from `slack_notification_error?()` in `crash_monitor.ex` to prevent false positives in crash detection.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for 617a555ece98354af930a51b9a43aa1d6ed6a7c5. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->