### PR TITLE
patch: increase size of stacktrace in notification

### DIFF
--- a/lib/core/notifications/slack.ex
+++ b/lib/core/notifications/slack.ex
@@ -229,10 +229,10 @@ defmodule Core.Notifications.Slack do
       # Add stacktrace section if provided
       blocks =
         if stacktrace && stacktrace != "" do
-          stacktrace_preview = String.slice(stacktrace, 0, 500)
+          stacktrace_preview = String.slice(stacktrace, 0, 1000)
 
           stacktrace_text =
-            if String.length(stacktrace) > 500,
+            if String.length(stacktrace) > 1000,
               do: stacktrace_preview <> "...",
               else: stacktrace_preview
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Increase stacktrace preview size in Slack notifications from 500 to 1000 characters in `slack.ex`.
> 
>   - **Behavior**:
>     - Increase stacktrace preview size from 500 to 1000 characters in `notify_crash` function in `slack.ex`.
>     - Adjusts condition to append "..." if stacktrace exceeds 1000 characters.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for 24c4a28a444652b458d30f0432bbafbbe69c7ece. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->