### PR TITLE
patch: fix credo warnings

### DIFF
--- a/lib/core/crm/companies/company_enrich.ex
+++ b/lib/core/crm/companies/company_enrich.ex
@@ -261,7 +261,7 @@ defmodule Core.Crm.Companies.CompanyEnrich do
   defp lookup_industry(industry_code, company_id) do
     case Industries.get_by_code(industry_code) do
       nil ->
-        OpenTelemetry.Tracer.set_status(:error, :industry_not_found)
+        OpenTelemetry.Tracer.set_status(:error, "Industry not found")
 
         OpenTelemetry.Tracer.set_attributes([
           {"error.reason", "Industry not found"}
@@ -638,7 +638,7 @@ defmodule Core.Crm.Companies.CompanyEnrich do
   end
 
   # Private helper methods
-  @spec should_enrich_industry?(%Company{}) :: boolean()
+  @spec should_enrich_industry?(Company.t()) :: boolean()
   defp should_enrich_industry?(%Company{} = company) do
     OpenTelemetry.Tracer.with_span "company_enrich.should_enrich_industry?" do
       OpenTelemetry.Tracer.set_attributes([
@@ -666,7 +666,7 @@ defmodule Core.Crm.Companies.CompanyEnrich do
 
   defp should_enrich_industry?(_), do: false
 
-  @spec should_enrich_name?(%Company{}) :: boolean()
+  @spec should_enrich_name?(Company.t()) :: boolean()
   defp should_enrich_name?(%Company{} = company) do
     OpenTelemetry.Tracer.with_span "company_enrich.should_enrich_name?" do
       OpenTelemetry.Tracer.set_attributes([
@@ -694,7 +694,7 @@ defmodule Core.Crm.Companies.CompanyEnrich do
 
   defp should_enrich_name?(_), do: false
 
-  @spec should_enrich_country?(%Company{}) :: boolean()
+  @spec should_enrich_country?(Company.t()) :: boolean()
   defp should_enrich_country?(%Company{} = company) do
     OpenTelemetry.Tracer.with_span "company_enrich.should_enrich_country?" do
       OpenTelemetry.Tracer.set_attributes([
@@ -722,7 +722,7 @@ defmodule Core.Crm.Companies.CompanyEnrich do
 
   defp should_enrich_country?(_), do: false
 
-  @spec should_enrich_icon?(%Company{}) :: boolean()
+  @spec should_enrich_icon?(Company.t()) :: boolean()
   defp should_enrich_icon?(%Company{} = company) do
     OpenTelemetry.Tracer.with_span "company_enrich.should_enrich_icon?" do
       OpenTelemetry.Tracer.set_attributes([
@@ -742,7 +742,7 @@ defmodule Core.Crm.Companies.CompanyEnrich do
 
   defp should_enrich_icon?(_), do: false
 
-  @spec should_scrape_homepage?(%Company{}) :: boolean()
+  @spec should_scrape_homepage?(Company.t()) :: boolean()
   defp should_scrape_homepage?(%Company{} = company) do
     OpenTelemetry.Tracer.with_span "company_enrich.should_scrape_homepage?" do
       OpenTelemetry.Tracer.set_attributes([

--- a/lib/core/researcher/scraped_webpages.ex
+++ b/lib/core/researcher/scraped_webpages.ex
@@ -31,9 +31,6 @@ defmodule Core.Researcher.ScrapedWebpages do
         |> maybe_add_classification(classification)
         |> maybe_add_intent(intent)
 
-      # Debug: Let's see the final attributes
-      IO.inspect(attrs, label: "Final attributes")
-
       changeset =
         %ScrapedWebpage{}
         |> ScrapedWebpage.changeset(attrs)
@@ -148,7 +145,6 @@ defmodule Core.Researcher.ScrapedWebpages do
   ## Helpers ##
 
   defp maybe_add_classification(attrs, nil) do
-    IO.puts("Classification is nil")
     attrs
   end
 

--- a/lib/web/user_auth.ex
+++ b/lib/web/user_auth.ex
@@ -41,8 +41,6 @@ defmodule Web.UserAuth do
 
   def signup_user(conn, user, params \\ %{}) do
     token = Users.generate_user_session_token(user)
-    user_return_to = get_session(conn, :user_return_to)
-    dbg(user_return_to)
 
     conn
     |> renew_session()

--- a/scripts/runners/build-core.sh
+++ b/scripts/runners/build-core.sh
@@ -5,7 +5,7 @@ APP_PATH=$1
 
 cd $APP_PATH
 
-export MIX_ENV=test
+export MIX_ENV=prod
 export BUN_INSTALL="$HOME/.bun"
 export PATH="$BUN_INSTALL/bin:$PATH"
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes Credo warnings, removes debug statements, and sets `MIX_ENV` to `prod` in `build-core.sh`.
> 
>   - **Code Quality**:
>     - Fixes Credo warnings by updating `@spec` types in `company_enrich.ex`.
>     - Changes `OpenTelemetry.Tracer.set_status` error message to a string in `company_enrich.ex`.
>   - **Debugging**:
>     - Removes `IO.inspect` and `IO.puts` debug statements from `scraped_webpages.ex`.
>     - Removes `dbg` statement from `user_auth.ex`.
>   - **Environment**:
>     - Changes `MIX_ENV` from `test` to `prod` in `build-core.sh`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for d2d69e0a9b0b57442010b080d52ec31ebf2181c0. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->