### PR TITLE
patch: icp fit attempts

### DIFF
--- a/lib/application.ex
+++ b/lib/application.ex
@@ -15,6 +15,7 @@ defmodule Core.Application do
       Core.Repo,
       Core.Crm.Companies.CompanyEnricher,
       Core.Crm.Companies.CompanyDomainProcessor,
+      Core.Crm.Leads.IcpFitEvaluator,
       Core.WebTracker.SessionCloser,
       Web.Endpoint,
       Web.Presence,

--- a/lib/core/crm/leads/icp_fit_evaluator.ex
+++ b/lib/core/crm/leads/icp_fit_evaluator.ex
@@ -1,0 +1,142 @@
+defmodule Core.Crm.Leads.IcpFitEvaluator do
+  @moduledoc """
+  GenServer responsible for evaluating and setting proper stages for leads.
+
+  This module:
+  * Monitors leads that need stage evaluation
+  * Retries evaluation for leads stuck in pending stage
+  """
+
+  use GenServer
+  require Logger
+  require OpenTelemetry.Tracer
+  import Ecto.Query
+  alias Core.Crm.Leads
+  alias Core.Crm.Leads.Lead
+  alias Core.Repo
+  alias Core.Utils.Tracing
+
+  # Constants
+  # 1 minute in milliseconds
+  @default_interval 60_000
+  # Number of leads to process in each batch
+  @default_batch_size 5
+
+  @doc """
+  Starts the stage evaluator process.
+  """
+  def start_link(_opts) do
+    crons_enabled = Application.get_env(:core, :crons)[:enabled] || false
+
+    if crons_enabled do
+      GenServer.start_link(__MODULE__, %{}, name: __MODULE__)
+    else
+      Logger.info("Stage evaluator is disabled (crons disabled)")
+      :ignore
+    end
+  end
+
+  # Server Callbacks
+
+  @impl true
+  def init(_) do
+    schedule_initial_check()
+
+    {:ok, %{}}
+  end
+
+  @impl true
+  def handle_info(:check_pending_leads, state) do
+    OpenTelemetry.Tracer.with_span "icp_fit_evaluator.check_pending_leads" do
+      leads = fetch_leads_for_icp_fit_evaluation()
+
+      OpenTelemetry.Tracer.set_attributes([
+        {"batch_size", @default_batch_size},
+        {"leads.count", length(leads)}
+      ])
+
+      Enum.each(leads, fn lead ->
+        case Leads.get_by_id(lead.tenant_id, lead.id) do
+          {:ok, lead} ->
+            Logger.info("Evaluating lead stage for lead_id: #{lead.id}")
+
+            # Mark the attempt before evaluation
+            case Leads.mark_icp_fit_attempt(lead.id) do
+              :ok ->
+                domain =
+                  case Core.Crm.Companies.get_by_id(lead.ref_id) do
+                    {:ok, company} ->
+                      company.primary_domain
+
+                    {:error, :not_found} ->
+                      Logger.error(
+                        "Company not found for lead #{lead.id} (ref_id: #{lead.ref_id})"
+                      )
+
+                      Tracing.error(:company_not_found)
+                      nil
+                  end
+
+                if domain do
+                  case Core.Researcher.IcpFitEvaluator.evaluate(domain, lead) do
+                    {:ok, _} ->
+                      :ok
+
+                    {:error, reason} ->
+                      Logger.error(
+                        "Failed to evaluate lead #{lead.id}: #{inspect(reason)}"
+                      )
+
+                      Tracing.error(reason)
+                  end
+                end
+
+              {:error, :update_failed} ->
+                Logger.error(
+                  "Failed to mark ICP fit attempt for lead: #{lead.id}"
+                )
+
+                Tracing.error(:update_failed)
+            end
+
+          {:error, :not_found} ->
+            Logger.error("Lead not found for evaluation: #{lead.id}")
+            Tracing.error(:not_found)
+        end
+      end)
+
+      schedule_next_check()
+      {:noreply, state}
+    end
+  end
+
+  # Private Functions
+
+  defp schedule_initial_check do
+    Process.send_after(self(), :check_pending_leads, @default_interval)
+  end
+
+  defp schedule_next_check do
+    Process.send_after(self(), :check_pending_leads, @default_interval)
+  end
+
+  defp fetch_leads_for_icp_fit_evaluation() do
+    hours_ago_24 = DateTime.add(DateTime.utc_now(), -24 * 60 * 60)
+    minutes_ago_10 = DateTime.add(DateTime.utc_now(), -10 * 60)
+    max_attempts = 5
+
+    Lead
+    |> where([l], l.type == :company)
+    |> where([l], l.stage == :pending)
+    |> where([l], l.icp_fit_evaluation_attempts < ^max_attempts)
+    |> where(
+      [l],
+      is_nil(l.icp_fit_evaluation_attempt_at) or
+        l.icp_fit_evaluation_attempt_at < ^hours_ago_24
+    )
+    |> where([l], l.inserted_at < ^minutes_ago_10)
+    |> order_by([l], asc_nulls_first: l.icp_fit_evaluation_attempt_at)
+    |> limit(^@default_batch_size)
+    |> Repo.all()
+  end
+end

--- a/lib/core/crm/leads/lead.ex
+++ b/lib/core/crm/leads/lead.ex
@@ -32,6 +32,8 @@ defmodule Core.Crm.Leads.Lead do
           stage: lead_stage,
           icp_fit: icp_fit,
           error_message: String.t(),
+          icp_fit_attempt_at: DateTime.t(),
+          icp_fit_attempts: integer(),
           inserted_at: DateTime.t(),
           updated_at: DateTime.t()
         }
@@ -58,6 +60,8 @@ defmodule Core.Crm.Leads.Lead do
     )
 
     field(:error_message, :string)
+    field(:icp_fit_attempt_at, :utc_datetime)
+    field(:icp_fit_attempts, :integer, default: 0)
 
     timestamps(type: :utc_datetime)
   end
@@ -72,7 +76,9 @@ defmodule Core.Crm.Leads.Lead do
     :id,
     :stage,
     :icp_fit,
-    :error_message
+    :error_message,
+    :icp_fit_attempt_at,
+    :icp_fit_attempts
   ]
 
   def changeset(%__MODULE__{} = lead, attrs) do

--- a/lib/core/crm/leads/lead.ex
+++ b/lib/core/crm/leads/lead.ex
@@ -32,8 +32,8 @@ defmodule Core.Crm.Leads.Lead do
           stage: lead_stage,
           icp_fit: icp_fit,
           error_message: String.t(),
-          icp_fit_attempt_at: DateTime.t(),
-          icp_fit_attempts: integer(),
+          icp_fit_evaluation_attempt_at: DateTime.t(),
+          icp_fit_evaluation_attempts: integer(),
           inserted_at: DateTime.t(),
           updated_at: DateTime.t()
         }
@@ -60,8 +60,8 @@ defmodule Core.Crm.Leads.Lead do
     )
 
     field(:error_message, :string)
-    field(:icp_fit_attempt_at, :utc_datetime)
-    field(:icp_fit_attempts, :integer, default: 0)
+    field(:icp_fit_evaluation_attempt_at, :utc_datetime)
+    field(:icp_fit_evaluation_attempts, :integer, default: 0)
 
     timestamps(type: :utc_datetime)
   end
@@ -77,8 +77,8 @@ defmodule Core.Crm.Leads.Lead do
     :stage,
     :icp_fit,
     :error_message,
-    :icp_fit_attempt_at,
-    :icp_fit_attempts
+    :icp_fit_evaluation_attempt_at,
+    :icp_fit_evaluation_attempts
   ]
 
   def changeset(%__MODULE__{} = lead, attrs) do

--- a/priv/repo/migrations/20250603055128_add_stage_timestamp_and_try_attempts_to_leads.exs
+++ b/priv/repo/migrations/20250603055128_add_stage_timestamp_and_try_attempts_to_leads.exs
@@ -3,22 +3,22 @@ defmodule Core.Repo.Migrations.AddStageTimestampAndTryAttemptsToLeads do
 
   def up do
     alter table(:leads) do
-      add :icp_fit_attempt_at, :utc_datetime
-      add :icp_fit_attempts, :integer, default: 0, null: false
+      add :icp_fit_evaluation_attempt_at, :utc_datetime
+      add :icp_fit_evaluation_attempts, :integer, default: 0, null: false
     end
 
     # Create index for efficient querying of leads that need ICP fit evaluation
-    create index(:leads, [:icp_fit_attempts, :icp_fit_attempt_at])
+    create index(:leads, [:icp_fit_evaluation_attempts, :icp_fit_evaluation_attempt_at])
   end
 
   def down do
     # Drop index first
-    drop index(:leads, [:icp_fit_attempts, :icp_fit_attempt_at])
+    drop index(:leads, [:icp_fit_evaluation_attempts, :icp_fit_evaluation_attempt_at])
 
     # Remove columns
     alter table(:leads) do
-      remove :icp_fit_attempt_at
-      remove :icp_fit_attempts
+      remove :icp_fit_evaluation_attempt_at
+      remove :icp_fit_evaluation_attempts
     end
   end
 end

--- a/priv/repo/migrations/20250603055128_add_stage_timestamp_and_try_attempts_to_leads.exs
+++ b/priv/repo/migrations/20250603055128_add_stage_timestamp_and_try_attempts_to_leads.exs
@@ -1,0 +1,24 @@
+defmodule Core.Repo.Migrations.AddStageTimestampAndTryAttemptsToLeads do
+  use Ecto.Migration
+
+  def up do
+    alter table(:leads) do
+      add :icp_fit_attempt_at, :utc_datetime
+      add :icp_fit_attempts, :integer, default: 0, null: false
+    end
+
+    # Create index for efficient querying of leads that need ICP fit evaluation
+    create index(:leads, [:icp_fit_attempts, :icp_fit_attempt_at])
+  end
+
+  def down do
+    # Drop index first
+    drop index(:leads, [:icp_fit_attempts, :icp_fit_attempt_at])
+
+    # Remove columns
+    alter table(:leads) do
+      remove :icp_fit_attempt_at
+      remove :icp_fit_attempts
+    end
+  end
+end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds `IcpFitEvaluator` GenServer for lead stage evaluation and updates `Lead` schema to track evaluation attempts.
> 
>   - **Behavior**:
>     - Adds `IcpFitEvaluator` GenServer in `icp_fit_evaluator.ex` to evaluate lead stages and retry pending evaluations.
>     - Integrates `IcpFitEvaluator` into `Core.Application` supervision tree.
>     - Adds `mark_icp_fit_attempt/1` in `leads.ex` to update attempt timestamp and counter.
>   - **Schema Changes**:
>     - Adds `icp_fit_evaluation_attempt_at` and `icp_fit_evaluation_attempts` fields to `Lead` schema in `lead.ex`.
>     - Updates migration script to add these fields and create an index in `20250603055128_add_stage_timestamp_and_try_attempts_to_leads.exs`.
>   - **Misc**:
>     - Adds logging and tracing for evaluation processes in `icp_fit_evaluator.ex`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for 572c8651aea196d5e6f56b9603dda9e377de7188. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->