### PR TITLE
patch: determine lead stage

### DIFF
--- a/lib/core/crm/companies/company_enrich.ex
+++ b/lib/core/crm/companies/company_enrich.ex
@@ -141,11 +141,6 @@ defmodule Core.Crm.Companies.CompanyEnrich do
       {:ok, result} ->
         {:ok, result.content}
 
-      {:error, :empty_content} ->
-        Logger.warning(
-          "No webpage content for #{company.id} | domain: #{company.primary_domain}"
-        )
-
       {:error, reason} ->
         Logger.error(
           "Failed to scrape homepage for company #{company.id} (domain: #{company.primary_domain}): #{inspect(reason)}"

--- a/lib/core/crm/leads.ex
+++ b/lib/core/crm/leads.ex
@@ -42,6 +42,13 @@ defmodule Core.Crm.Leads do
     |> extract_company_domain()
   end
 
+  def get_lead_by_company_ref(tenant_id, ref_id) do
+    case Repo.get_by(Lead, tenant_id: tenant_id, ref_id: ref_id, type: :company) do
+      %Lead{} = lead -> {:ok, lead}
+      nil -> {:error, :not_found}
+    end
+  end
+
   @spec list_by_tenant_id(tenant_id :: String.t()) ::
           {:ok, [Lead.t()]} | {:error, :not_found}
   def list_by_tenant_id(tenant_id) do

--- a/lib/core/researcher/scraper.ex
+++ b/lib/core/researcher/scraper.ex
@@ -96,7 +96,7 @@ defmodule Core.Researcher.Scraper do
         :ok
 
       {:error, reason} ->
-        Logger.error("Failed processing scraped content for #{content}")
+        Logger.error("Failed processing scraped content for #{url}")
         {:error, reason}
     end
   end
@@ -224,6 +224,9 @@ defmodule Core.Researcher.Scraper do
         @err_unprocessable
 
       String.contains?(content, "Why have I been blocked?") ->
+        @err_unprocessable
+
+      String.contains?(content, "Privacy error") ->
         @err_unprocessable
 
       true ->

--- a/lib/core/web_tracker/stage_identifier.ex
+++ b/lib/core/web_tracker/stage_identifier.ex
@@ -1,0 +1,62 @@
+defmodule Core.WebTracker.StageIdentifier do
+  alias Core.WebTracker.StageIdentifier.SessionContext
+
+  def identify(page_visits)
+      when is_list(page_visits) and length(page_visits) > 0 do
+    if Enum.all?(page_visits, &match?(%SessionContext{}, &1)) do
+      page_visits
+      |> calculate_session_stage_scores()
+      |> determine_primary_stage()
+    else
+      {:error, :invalid_struct_type}
+    end
+  end
+
+  def identify(_), do: {:error, :invalid_input}
+
+  defp calculate_session_stage_scores(page_visits) do
+    totals =
+      Enum.reduce(
+        page_visits,
+        %{
+          total_problem_recognition: 0,
+          total_solution_research: 0,
+          total_evaluation: 0,
+          total_purchase_readiness: 0
+        },
+        fn page, acc ->
+          intent = elem(page, 2)
+
+          %{
+            total_problem_recognition:
+              acc.total_problem_recognition + intent.problem_recognition,
+            total_solution_research:
+              acc.total_solution_research + intent.solution_research,
+            total_evaluation: acc.total_evaluation + intent.evaluation,
+            total_purchase_readiness:
+              acc.total_purchase_readiness + intent.purchase_readiness
+          }
+        end
+      )
+
+    {:ok, totals}
+  end
+
+  defp determine_primary_stage({:ok, totals}) do
+    # Order matters - later stages win ties (more advanced in buyer journey)
+    stage_scores = [
+      {:education, totals.total_problem_recognition},
+      {:solution, totals.total_solution_research},
+      {:evaluation, totals.total_evaluation},
+      {:ready_to_buy, totals.total_purchase_readiness}
+    ]
+
+    {primary_stage, _max_score} =
+      stage_scores
+      # Reverse so later stages win ties
+      |> Enum.reverse()
+      |> Enum.max_by(fn {_stage, score} -> score end)
+
+    {:ok, primary_stage}
+  end
+end

--- a/lib/core/web_tracker/stage_identifier/session_context.ex
+++ b/lib/core/web_tracker/stage_identifier/session_context.ex
@@ -1,0 +1,7 @@
+defmodule Core.WebTracker.StageIdentifier.SessionContext do
+  @moduledoc """
+  Struct representing the context for Lead Stage identification from a websession.
+  """
+
+  defstruct [:url, :summary, :intent]
+end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds lead stage determination from web sessions and integrates it into existing modules, with fixes and improvements.
> 
>   - **Behavior**:
>     - Adds `get_lead_by_company_ref/2` in `leads.ex` to fetch leads by company reference.
>     - Adds `update_classification_and_intent/3` and `update_webpage/2` in `webpages.ex` for updating webpage data.
>     - Adds `identify/1` in `stage_identifier.ex` to determine lead stage from page visits.
>     - Updates `analyze_session/1` in `session_analyzer.ex` to determine lead stage and update lead.
>     - Fixes missing `{:ok, ...}` pattern in `update_classification/2` and `update_intent/2` in `webpages.ex`.
>     - Fixes logging error in `scraper.ex` to log URL instead of content.
>   - **Models**:
>     - Adds `SessionContext` struct in `session_context.ex` for lead stage identification.
>   - **Misc**:
>     - Removes unused `:empty_content` error handling in `company_enrich.ex`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for d347b78f130d965e327cefe914ab51702c29087c. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->