### PR TITLE
patch: fix icp eval

### DIFF
--- a/lib/core/researcher/crawler.ex
+++ b/lib/core/researcher/crawler.ex
@@ -157,7 +157,19 @@ defmodule Core.Researcher.Crawler do
   end
 
   defp queue_new_links(state, content, depth) do
-    new_links = extract_new_links(Map.get(content, :links, []), depth, state)
+    links =
+      case content do
+        %{links: links} when is_list(links) ->
+          links
+
+        content when is_binary(content) ->
+          Core.Researcher.Webpages.LinkExtractor.extract_links(content)
+
+        _ ->
+          []
+      end
+
+    new_links = extract_new_links(links, depth, state)
     %{state | queue: state.queue ++ new_links}
   end
 

--- a/lib/core/researcher/icp_fit_evaluator.ex
+++ b/lib/core/researcher/icp_fit_evaluator.ex
@@ -64,10 +64,10 @@ defmodule Core.Researcher.IcpFitEvaluator do
        when fit in [:strong, :moderate, :not_a_fit] do
     case fit do
       :strong ->
-        Leads.update_lead(lead, %{icp_fit: :strong, stage: :education})
+        Leads.update_lead(lead, %{icp_fit: :strong})
 
       :moderate ->
-        Leads.update_lead(lead, %{icp_fit: :moderate, stage: :education})
+        Leads.update_lead(lead, %{icp_fit: :moderate})
 
       :not_a_fit ->
         Leads.update_lead(lead, %{stage: :not_a_fit})

--- a/lib/core/researcher/webpages/classifier.ex
+++ b/lib/core/researcher/webpages/classifier.ex
@@ -3,6 +3,7 @@ defmodule Core.Researcher.Webpages.Classifier do
   Classifies webpage content using AI.
   """
   alias Core.Ai
+  require Logger
 
   @model :gemini_pro
   @model_temperature 0.2
@@ -21,6 +22,10 @@ defmodule Core.Researcher.Webpages.Classifier do
   end
 
   def classify_content(url, content) when is_binary(content) do
+    Logger.info("Starting classify content analysis for #{url}",
+      url: url
+    )
+
     {system_prompt, prompt} =
       build_classify_webpage_prompts(url, content)
 
@@ -29,7 +34,8 @@ defmodule Core.Researcher.Webpages.Classifier do
         model: @model,
         system_prompt: system_prompt,
         temperature: @model_temperature,
-        max_tokens: @max_tokens
+        max_tokens: @max_tokens,
+        response_type: :json
       )
 
     task = Ai.ask_supervised(request)

--- a/lib/core/researcher/webpages/intent_profiler.ex
+++ b/lib/core/researcher/webpages/intent_profiler.ex
@@ -4,6 +4,7 @@ defmodule Core.Researcher.Webpages.IntentProfiler do
   """
   alias Core.Ai
   alias Core.Utils.Tracing
+  require Logger
 
   @model :claude_sonnet
   @model_temperature 0.2
@@ -32,6 +33,10 @@ defmodule Core.Researcher.Webpages.IntentProfiler do
   end
 
   def profile_intent(url, content) when is_binary(content) and content != "" do
+    Logger.info("Starting profile intent analysis for #{url}",
+      url: url
+    )
+
     {system_prompt, prompt} = build_profile_intent_prompts(url, content)
 
     request =


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Improves webpage content classification, intent profiling, and ICP fit evaluation with enhanced error handling and logging.
> 
>   - **Behavior**:
>     - `queue_new_links/3` in `crawler.ex` now handles content as a binary or map with `:links` key.
>     - `update_lead/2` in `icp_fit_evaluator.ex` no longer updates `stage` for `:strong` and `:moderate` fits.
>     - `classify_content/2` added to `scraper.ex` for content classification.
>   - **Logging**:
>     - Added logging in `classifier.ex` and `intent_profiler.ex` for content analysis start.
>     - Enhanced logging in `session_analyzer.ex` for task results and errors.
>   - **Error Handling**:
>     - Improved error handling in `session_analyzer.ex` for task exits and unexpected results.
>     - Added error handling for task timeouts in `scraper.ex` and `classifier.ex`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for 00fe4c97963e05d6b6ecf96fa117db35ee3899b7. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->