### PR TITLE
patch: script to re-run stage selection

### DIFF
--- a/lib/core/crm/leads.ex
+++ b/lib/core/crm/leads.ex
@@ -122,6 +122,17 @@ defmodule Core.Crm.Leads do
     end
   end
 
+  def get_icp_fits_without_stage() do
+    Lead
+    |> where([l], l.icp_fit in [:strong, :moderate])
+    |> where([l], l.stage in [:pending, :target])
+    |> Repo.all()
+    |> then(fn
+      [] -> {:error, :not_found}
+      leads -> {:ok, leads}
+    end)
+  end
+
   @spec get_or_create(tenant :: String.t(), attrs :: map()) ::
           {:ok, Lead.t()} | {:error, :not_found}
   def get_or_create(tenant, attrs) do

--- a/lib/core/researcher/crawler.ex
+++ b/lib/core/researcher/crawler.ex
@@ -25,8 +25,8 @@ defmodule Core.Researcher.Crawler do
   defp crawl(domain, opts) when is_binary(domain) do
     case Core.Utils.DomainExtractor.extract_base_domain(domain) do
       {:ok, base_domain} ->
-        # Start crawling with concurrent workers
         home_page_url = Core.Utils.UrlFormatter.to_https(base_domain)
+
         crawl_concurrent(%{
           queue: [{home_page_url, 0}],
           visited: MapSet.new(),

--- a/lib/core/researcher/scraper.ex
+++ b/lib/core/researcher/scraper.ex
@@ -19,6 +19,7 @@ defmodule Core.Researcher.Scraper do
 
   require OpenTelemetry.Tracer
   require Logger
+  alias Researcher.Scraper.Filter
   alias Core.Researcher.Webpages
   alias Core.Researcher.Webpages.Classifier
   alias Core.Utils.PrimaryDomainFinder
@@ -70,7 +71,8 @@ defmodule Core.Researcher.Scraper do
   end
 
   defp validate_url(url) do
-    with {:ok, host} <- DomainExtractor.extract_base_domain(url),
+    with {:ok, true} <- Filter.should_scrape?(url),
+         {:ok, host} <- DomainExtractor.extract_base_domain(url),
          {:ok, true} <- PrimaryDomainFinder.primary_domain?(host),
          {:ok, base_url} <- UrlFormatter.get_base_url(url),
          {:ok, clean_url} <- UrlFormatter.to_https(base_url) do

--- a/lib/core/researcher/scraper/filter.ex
+++ b/lib/core/researcher/scraper/filter.ex
@@ -1,0 +1,258 @@
+defmodule Researcher.Scraper.Filter do
+  @doc """
+  Determines if a webpage should be scraped based on its URL.
+  Returns true if the page likely contains marketing/content, false for admin/app pages.
+  """
+  def should_scrape?(url) when is_binary(url) do
+    url
+    |> String.downcase()
+    |> URI.parse()
+    |> extract_path()
+    |> should_scrape_path?()
+  end
+
+  def should_scrape?(_), do: {:ok, false}
+
+  # Extract path and handle edge cases
+  defp extract_path(%URI{path: nil}), do: "/"
+  defp extract_path(%URI{path: path}), do: path
+
+  # Check if path should be scraped
+  defp should_scrape_path?(path) do
+    cond do
+      # Always scrape root and basic pages
+      path in ["/", "", "/home", "/index"] -> {:ok, true}
+      # Skip if contains excluded segments
+      contains_excluded_segments?(path) -> {:ok, false}
+      # Skip if has excluded file extensions
+      has_excluded_extension?(path) -> {:ok, false}
+      # Skip if looks like an ID/UUID path
+      looks_like_id_path?(path) -> {:ok, false}
+      # Default to scraping
+      true -> {:ok, true}
+    end
+  end
+
+  # Common admin/app path segments to exclude
+  defp contains_excluded_segments?(path) do
+    excluded_segments = [
+      # Admin/Management
+      "admin",
+      "dashboard",
+      "manage",
+      "control",
+      "panel",
+      "backend",
+
+      # Authentication
+      "login",
+      "signin",
+      "signup",
+      "register",
+      "auth",
+      "oauth",
+      "sso",
+      "logout",
+      "signout",
+      "password",
+      "reset",
+      "verify",
+      "confirm",
+
+      # User Account/App Areas
+      "app",
+      "account",
+      "profile",
+      "settings",
+      "preferences",
+      "config",
+      "user",
+      "member",
+      "my-",
+      "portal",
+      "console",
+      "workspace",
+
+      # API/Technical
+      "api",
+      "webhook",
+      "callback",
+      "ws",
+      "socket",
+      "graphql",
+      "rpc",
+      "health",
+      "status",
+      "metrics",
+      "monitor",
+      "debug",
+
+      # CMS/Internal
+      "cms",
+      "editor",
+      "draft",
+      "preview",
+      "admin",
+      "wp-admin",
+      "wp-login",
+      "phpmyadmin",
+      "cpanel",
+      "plesk",
+
+      # E-commerce Internal
+      "checkout",
+      "cart",
+      "payment",
+      "billing",
+      "invoice",
+      "receipt",
+      "order",
+      "transaction",
+      "purchase",
+
+      # Development/Testing
+      "test",
+      "staging",
+      "dev",
+      "demo",
+      "sandbox",
+      "temp",
+      "tmp",
+      "localhost",
+      "127.0.0.1",
+
+      # File Management
+      "upload",
+      "download",
+      "file",
+      "files",
+      "assets",
+      "static",
+      "media",
+      "images",
+      "css",
+      "js",
+      "fonts",
+
+      # Common Exclusions
+      "404",
+      "500",
+      "error",
+      "maintenance",
+      "coming-soon",
+      "terms",
+      "privacy",
+      "legal",
+      "cookies",
+      "gdpr"
+    ]
+
+    path_segments = String.split(path, "/", trim: true)
+
+    Enum.any?(path_segments, fn segment ->
+      segment_lower = String.downcase(segment)
+
+      Enum.any?(excluded_segments, fn excluded ->
+        String.contains?(segment_lower, excluded)
+      end)
+    end)
+  end
+
+  # File extensions that shouldn't be scraped
+  defp has_excluded_extension?(path) do
+    excluded_extensions = [
+      # Documents
+      ".pdf",
+      ".doc",
+      ".docx",
+      ".xls",
+      ".xlsx",
+      ".ppt",
+      ".pptx",
+
+      # Media
+      ".jpg",
+      ".jpeg",
+      ".png",
+      ".gif",
+      ".svg",
+      ".webp",
+      ".ico",
+      ".mp4",
+      ".mov",
+      ".avi",
+      ".mp3",
+      ".wav",
+
+      # Archives
+      ".zip",
+      ".rar",
+      ".tar",
+      ".gz",
+      ".7z",
+
+      # Code/Data
+      ".json",
+      ".xml",
+      ".csv",
+      ".txt",
+      ".log",
+      ".js",
+      ".css",
+      ".map",
+      ".woff",
+      ".woff2",
+      ".ttf",
+
+      # Feeds
+      ".rss",
+      ".atom",
+      ".sitemap"
+    ]
+
+    path_lower = String.downcase(path)
+    Enum.any?(excluded_extensions, &String.ends_with?(path_lower, &1))
+  end
+
+  # Check if path looks like an ID (UUIDs, long numbers, etc.)
+  defp looks_like_id_path?(path) do
+    path_segments = String.split(path, "/", trim: true)
+
+    Enum.any?(path_segments, fn segment ->
+      # UUID pattern
+      uuid_pattern =
+        ~r/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+      # Long number (likely an ID)
+      long_number_pattern = ~r/^\d{6,}$/
+
+      # Hash-like string
+      hash_pattern = ~r/^[a-f0-9]{16,}$/i
+
+      Regex.match?(uuid_pattern, segment) or
+        Regex.match?(long_number_pattern, segment) or
+        Regex.match?(hash_pattern, segment)
+    end)
+  end
+
+  @doc """
+  Batch filter URLs - useful for processing lists
+  """
+  def filter_scrapeable_urls(urls) when is_list(urls) do
+    Enum.filter(urls, &should_scrape?/1)
+  end
+
+  @doc """
+  Get reasons why a URL was excluded (for debugging)
+  """
+  def exclusion_reason(url) when is_binary(url) do
+    path = url |> String.downcase() |> URI.parse() |> extract_path()
+
+    cond do
+      contains_excluded_segments?(path) -> {:excluded, :admin_or_app_path}
+      has_excluded_extension?(path) -> {:excluded, :file_extension}
+      looks_like_id_path?(path) -> {:excluded, :id_path}
+      true -> {:included, :content_page}
+    end
+  end
+end

--- a/scripts/production/stage_selection.exs
+++ b/scripts/production/stage_selection.exs
@@ -1,0 +1,59 @@
+Application.ensure_all_started(:core)
+
+defmodule StageSelector do
+  alias Core.Crm.Leads
+  alias Core.Auth.Tenants
+  alias Core.WebTracker.Sessions
+  alias Core.WebTracker.SessionAnalyzer
+
+  def run_all() do
+    IO.puts("Getting ICP fits without an evaluated stage...")
+
+    case Leads.get_icp_fits_without_stage() do
+      {:error, :not_found} -> 
+        IO.puts("No leads to evaluate.")
+        
+      {:ok, leads} ->
+        IO.puts("Processing #{length(leads)} leads...")
+        
+        leads
+        |> Enum.with_index(1)
+        |> Enum.each(fn {lead, index} ->
+          IO.puts("[#{index}/#{length(leads)}] Processing lead: #{lead.ref_id}")
+          process_lead(lead)
+        end)
+        
+        IO.puts("Completed processing all leads.")
+    end
+  end
+
+  def run(lead_id, tenant_id) do
+    case Leads.get_by_id(tenant_id, lead_id) do
+      {:ok, lead} -> process_lead(lead)
+      {:error, reason} -> IO.puts("Unable to process lead: #{reason}")
+    end
+  end
+
+  defp process_lead(lead_record) do
+    with {:ok, tenant} <- Tenants.get_tenant_by_id(lead_record.tenant_id),
+         {:ok, sessions} <- Sessions.get_all_closed_sessions_by_tenant_and_company(tenant.name, lead_record.ref_id) do
+      
+      IO.puts("  Found #{length(sessions)} sessions for lead #{lead_record.ref_id}")
+      
+      Enum.each(sessions, fn session ->
+        IO.puts("    Starting analysis for session: #{session.id}")
+        SessionAnalyzer.analyze_session(session.id)
+      end)
+    else
+      {:error, :not_found} -> 
+        IO.puts("  ✗ Tenant #{lead_record.tenant_id} or Sessions not found for lead #{lead_record.ref_id}")
+        # Set to target when no sessions found
+        Leads.update_lead(lead_record, %{stage: :target})
+        
+      {:error, reason} ->
+        IO.puts("  ✗ Error processing lead #{lead_record.ref_id}: #{inspect(reason)}")
+    end
+  end
+end
+
+StageSelector.run_all()


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds script and functionality to re-run stage selection for leads without an evaluated stage, including session analysis updates and URL scraping filters.
> 
>   - **New Functionality**:
>     - Adds `get_icp_fits_without_stage()` in `leads.ex` to fetch leads with ICP fit but without an evaluated stage.
>     - Introduces `StageSelector` module in `stage_selection.exs` to process these leads and analyze their sessions.
>   - **Session Analysis**:
>     - Updates `session_analyzer.ex` to include `ok_to_run?()` for checking lead stage before analysis.
>     - Adds handling for `:stop` conditions in `determine_lead_stage()`.
>   - **Scraping**:
>     - Adds `filter.ex` to determine if a URL should be scraped based on its path and characteristics.
>     - Updates `scraper.ex` to use `Filter.should_scrape?()` in `validate_url()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for 698b23ef683b6866534980001c3b2579747f6a19. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->