### PR TITLE
patch: log slack raw response

### DIFF
--- a/lib/core/notifications/slack.ex
+++ b/lib/core/notifications/slack.ex
@@ -30,12 +30,18 @@ defmodule Core.Notifications.Slack do
         {:ok, %{status: 200}} ->
           :ok
 
-        {:ok, %{status: status_code}} ->
+        {:ok, %{status: status_code, body: body}} ->
           Logger.error("Slack API returned status code #{status_code}")
+          Logger.warning("Slack API response body: #{inspect(body)}")
           {:error, :slack_api_error}
 
         {:error, %Finch.Error{} = error} ->
           Logger.error("Failed to send Slack message: #{inspect(error)}")
+          case error do
+            %Finch.Error{reason: {:status, _status, body}} ->
+              Logger.warning("Slack API response body: #{inspect(body)}")
+            _ -> :ok
+          end
           {:error, error}
       end
     else


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add logging for Slack API response body in `send_message/2` for non-200 status codes and specific `Finch.Error` cases in `slack.ex`.
> 
>   - **Logging Enhancements**:
>     - In `send_message/2` in `slack.ex`, log Slack API response body on non-200 status codes.
>     - Log response body for `Finch.Error` with `{:status, _status, body}` reason in `slack.ex`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for 7c4f584aa7c02d21722934c6a40cba0ba2421bba. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->