### PR TITLE
patch: doc lookup joined w/ lead id

### DIFF
--- a/lib/core/crm/documents.ex
+++ b/lib/core/crm/documents.ex
@@ -243,7 +243,7 @@ defmodule Core.Crm.Documents do
   end
 
   @doc """
-  Gets documents and their assiciated lead_id for a specific tenant.
+  Gets documents and their associated lead_id for a specific tenant.
   """
   def list_all_by_tenant(tenant_id) do
     query =

--- a/lib/core/crm/documents.ex
+++ b/lib/core/crm/documents.ex
@@ -5,7 +5,7 @@ defmodule Core.Crm.Documents do
   import Ecto.Query, warn: false
   require Logger
   alias Core.Repo
-  alias Core.Crm.Documents.{Document, RefDocument}
+  alias Core.Crm.Documents.{Document, RefDocument, DocumentWithLead}
 
   def create_document(attrs \\ %{}, opts \\ []) do
     attrs
@@ -242,9 +242,27 @@ defmodule Core.Crm.Documents do
     """
   end
 
+  @doc """
+  Gets documents and their assiciated lead_id for a specific tenant.
+  """
   def list_all_by_tenant(tenant_id) do
-    from(d in Document, where: d.tenant_id == ^tenant_id)
-    |> Repo.all()
+    query =
+      from d in Document,
+        join: rd in RefDocument,
+        on: d.id == rd.document_id,
+        where: d.tenant_id == ^tenant_id,
+        select: %DocumentWithLead{
+          document_id: d.id,
+          document_name: d.name,
+          body: d.body,
+          tenant_id: d.tenant_id,
+          lead_id: rd.ref_id
+        }
+
+    case Repo.all(query) do
+      [] -> {:error, :not_found}
+      documents -> {:ok, documents}
+    end
   end
 
   defp maybe_insert_ref_document(multi, nil), do: multi

--- a/lib/core/crm/documents/document_with_lead.ex
+++ b/lib/core/crm/documents/document_with_lead.ex
@@ -1,0 +1,15 @@
+defmodule Core.Crm.Documents.DocumentWithLead do
+  @moduledoc """
+  Struct for documents joined with lead references
+  """
+
+  defstruct [:document_id, :document_name, :body, :tenant_id, :lead_id]
+
+  @type t :: %__MODULE__{
+          document_id: String.t(),
+          document_name: String.t(),
+          body: String.t(),
+          tenant_id: String.t(),
+          lead_id: String.t()
+        }
+end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `DocumentWithLead` struct and updates `list_all_by_tenant` to include lead IDs in `documents.ex`.
> 
>   - **Behavior**:
>     - `list_all_by_tenant/1` in `documents.ex` now returns documents with associated `lead_id`.
>     - Returns `{:error, :not_found}` if no documents are found.
>   - **Structs**:
>     - New struct `DocumentWithLead` in `document_with_lead.ex` to represent documents with lead references.
>   - **Imports/Aliases**:
>     - Added `DocumentWithLead` alias in `documents.ex`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for dea1fe62a1afd218503c7e0647d9ffc8aa2bd98b. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->