### PR TITLE
patch: fix crash on reading response form scrape_webpage

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -35,7 +35,9 @@ config :logger, :console,
     :icp_fit,
     :url,
     :session_id,
-    :message
+    :message,
+    :company,
+    :company_id
   ]
 
 # Phoenix

--- a/lib/core/crm/companies/company_enrich.ex
+++ b/lib/core/crm/companies/company_enrich.ex
@@ -144,8 +144,8 @@ defmodule Core.Crm.Companies.CompanyEnrich do
       ])
 
       case Scraper.scrape_webpage(company.primary_domain) do
-        {:ok, result} ->
-          {:ok, result.content}
+        {:ok, %{content: content}} when is_binary(content) ->
+          {:ok, content}
 
         {:error, reason} ->
           Logger.error(
@@ -297,7 +297,9 @@ defmodule Core.Crm.Companies.CompanyEnrich do
         Tracing.error(:industry_not_found)
 
         Logger.error(
-          "Industry code #{industry_code} not available in db", domain: company.primary_domain, company_id: company.id
+          "Industry code #{industry_code} not available in db",
+          domain: company.primary_domain,
+          company_id: company.id
         )
 
         {:error, :industry_not_found}

--- a/lib/core/notifications/crash_monitor.ex
+++ b/lib/core/notifications/crash_monitor.ex
@@ -84,6 +84,7 @@ defmodule Core.Notifications.CrashMonitor do
 
   defp slack_notification_error?(msg) do
     msg_str = to_string(msg)
+
     String.contains?(msg_str, [
       "Finch",
       "Slack",

--- a/lib/core/notifications/slack.ex
+++ b/lib/core/notifications/slack.ex
@@ -37,11 +37,15 @@ defmodule Core.Notifications.Slack do
 
         {:error, %Finch.Error{} = error} ->
           Logger.error("Failed to send Slack message: #{inspect(error)}")
+
           case error do
             %Finch.Error{reason: {:status, _status, body}} ->
               Logger.warning("Slack API response body: #{inspect(body)}")
-            _ -> :ok
+
+            _ ->
+              :ok
           end
+
           {:error, error}
       end
     else

--- a/lib/core/researcher/scraper.ex
+++ b/lib/core/researcher/scraper.ex
@@ -41,6 +41,14 @@ defmodule Core.Researcher.Scraper do
   @err_webscraper_timed_out {:error, "webscraper timed out"}
   @err_unexpected_response {:error, "webscraper returned unexpected response"}
 
+  @type scrape_result :: %{
+          content: String.t(),
+          summary: String.t() | nil,
+          links: [String.t()] | nil
+        }
+
+  @spec scrape_webpage(String.t()) ::
+          {:ok, String.t() | scrape_result()} | {:error, any()}
   def scrape_webpage(url) when is_binary(url) and byte_size(url) > 0 do
     Logger.metadata(module: __MODULE__, function: :scrape_webpage)
 
@@ -142,7 +150,11 @@ defmodule Core.Researcher.Scraper do
       case results do
         {:ok, {:ok, classification}} ->
           Webpages.update_classification(url, classification)
-          {:ok, content}
+
+          {:ok,
+           %{
+             content: content
+           }}
 
         {:ok, {:error, reason}} ->
           Tracing.error(reason)

--- a/lib/core/researcher/scraper/filter.ex
+++ b/lib/core/researcher/scraper/filter.ex
@@ -1,4 +1,8 @@
 defmodule Researcher.Scraper.Filter do
+  @moduledoc """
+  Filters out non-scrapeable URLs based on path and file extension.
+  """
+
   @doc """
   Determines if a webpage should be scraped based on its URL.
   Returns true if the page likely contains marketing/content, false for admin/app pages.

--- a/lib/core/web_tracker/session_analyzer.ex
+++ b/lib/core/web_tracker/session_analyzer.ex
@@ -171,7 +171,7 @@ defmodule Core.WebTracker.SessionAnalyzer do
 
   defp get_webpage_content({:ok, url}) do
     case Scraper.scrape_webpage(url) do
-      {:ok, _content} ->
+      {:ok, _} ->
         {:ok, url}
 
       {:error, reason} ->

--- a/lib/core/web_tracker/web_tracker.ex
+++ b/lib/core/web_tracker/web_tracker.ex
@@ -335,7 +335,10 @@ defmodule Core.WebTracker do
           Tracing.error("lead_creation_failed")
 
           Logger.error(
-            "Failed to create lead for company", reason: reason, company: company.name, domain: domain
+            "Failed to create lead for company",
+            reason: reason,
+            company: company.name,
+            domain: domain
           )
       end
     end

--- a/lib/web/components/layouts/root.html.heex
+++ b/lib/web/components/layouts/root.html.heex
@@ -42,6 +42,5 @@
 
   <body class="bg-white antialiased">
     {@inner_content}
-    
   </body>
 </html>

--- a/test/core/researcher/scraper_test.exs
+++ b/test/core/researcher/scraper_test.exs
@@ -67,7 +67,7 @@ defmodule Core.Researcher.ScraperTest do
         result = Scraper.scrape_webpage(url)
 
         case result do
-          {:ok, content} when is_binary(content) ->
+          {:ok, %{content: content}} when is_binary(content) ->
             assert String.length(content) > 0
 
           {:error, %{type: error_type}} when is_atom(error_type) ->


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix crash in `scrape_webpage` by changing return type to map with `content` key and update related modules and tests.
> 
>   - **Behavior**:
>     - Fix crash in `scrape_webpage` by changing return type to map with `content` key in `scraper.ex`.
>     - Update `scrape_company_homepage` in `company_enrich.ex` to handle new return type.
>     - Modify `get_webpage_content` in `session_analyzer.ex` to accommodate new return type.
>   - **Logging**:
>     - Add `company` and `company_id` to logger metadata in `config.exs`.
>     - Improve error logging in `slack.ex` and `crash_monitor.ex`.
>   - **Tests**:
>     - Update `scraper_test.exs` to test new return type of `scrape_webpage`.
>   - **Misc**:
>     - Add module doc to `filter.ex`.
>     - Remove trailing whitespace in `root.html.heex`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for 1683d9fbaa3ccbc75202f4403056ffb95aec8a40. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->