### PR TITLE
patch: use homepage content from scraping table

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -36,6 +36,7 @@ config :logger, :console,
     :url,
     :session_id,
     :message,
+    :name,
     :company,
     :company_id
   ]

--- a/lib/core/crm/companies/company.ex
+++ b/lib/core/crm/companies/company.ex
@@ -49,6 +49,7 @@ defmodule Core.Crm.Companies.Company do
     # Scraped content
     # home page
     field(:homepage_content, :string)
+    field(:homepage_scraped, :boolean, default: false)
 
     timestamps(type: :utc_datetime)
   end
@@ -78,6 +79,7 @@ defmodule Core.Crm.Companies.Company do
           linkedin_alias: String.t() | nil,
           # Scraped content
           homepage_content: String.t() | nil,
+          homepage_scraped: boolean(),
           inserted_at: DateTime.t(),
           updated_at: DateTime.t()
         }
@@ -106,7 +108,8 @@ defmodule Core.Crm.Companies.Company do
       :icon_enrichment_attempts,
       :linkedin_id,
       :linkedin_alias,
-      :homepage_content
+      :homepage_content,
+      :homepage_scraped
     ])
     |> validate_required([:id, :primary_domain])
     |> validate_format(:id, @id_regex)

--- a/lib/core/crm/companies/company_enricher.ex
+++ b/lib/core/crm/companies/company_enricher.ex
@@ -195,6 +195,7 @@ defmodule Core.Crm.Companies.CompanyEnricher do
     Company
     |> where([c], is_nil(c.industry_code) or c.industry_code == "")
     |> where([c], not is_nil(c.homepage_content) and c.homepage_content != "")
+    |> where([c], c.homepage_scraped == true)
     |> where([c], c.industry_enrichment_attempts < ^max_attempts)
     |> where(
       [c],
@@ -251,6 +252,7 @@ defmodule Core.Crm.Companies.CompanyEnricher do
     Company
     |> where([c], is_nil(c.name) or c.name == "")
     |> where([c], not is_nil(c.homepage_content) and c.homepage_content != "")
+    |> where([c], c.homepage_scraped == true)
     |> where([c], c.name_enrichment_attempts < ^max_attempts)
     |> where(
       [c],
@@ -307,6 +309,7 @@ defmodule Core.Crm.Companies.CompanyEnricher do
     Company
     |> where([c], is_nil(c.country_a2) or c.country_a2 == "")
     |> where([c], not is_nil(c.homepage_content) and c.homepage_content != "")
+    |> where([c], c.homepage_scraped == true)
     |> where([c], c.country_enrichment_attempts < ^max_attempts)
     |> where(
       [c],
@@ -365,6 +368,7 @@ defmodule Core.Crm.Companies.CompanyEnricher do
 
     Company
     |> where([c], is_nil(c.homepage_content) or c.homepage_content == "")
+    |> where([c], c.homepage_scraped == false)
     |> where([c], c.domain_scrape_attempts < ^max_attempts)
     |> where(
       [c],

--- a/lib/core/researcher/scraper.ex
+++ b/lib/core/researcher/scraper.ex
@@ -92,7 +92,7 @@ defmodule Core.Researcher.Scraper do
          {:ok, base_url} <- UrlFormatter.get_base_url(url),
          {:ok, clean_url} <- UrlFormatter.to_https(base_url),
          {:ok, content_type} <- fetch_content_type(clean_url),
-         {:ok, true} <- is_webpage_content_type(content_type) do
+         {:ok, true} <- webpage_content_type?(content_type) do
       clean_url
     else
       {:ok, false} ->
@@ -373,7 +373,7 @@ defmodule Core.Researcher.Scraper do
     end
   end
 
-  defp is_webpage_content_type(content_type) do
+  defp webpage_content_type?(content_type) do
     # Allow only HTML and similar web content
     if String.starts_with?(content_type, "text/html") do
       {:ok, true}

--- a/lib/core/researcher/scraper/content_processor.ex
+++ b/lib/core/researcher/scraper/content_processor.ex
@@ -91,7 +91,12 @@ defmodule Core.Researcher.Scraper.ContentProcessor do
 
         {:exit, reason} ->
           Tracing.error(reason)
-          Logger.error("Webpage summarization crashed", url: url, reason: reason)
+
+          Logger.error("Webpage summarization crashed",
+            url: url,
+            reason: reason
+          )
+
           @err_summary_crashed
 
         nil ->

--- a/lib/core/researcher/webpages/link_extractor.ex
+++ b/lib/core/researcher/webpages/link_extractor.ex
@@ -57,7 +57,7 @@ defmodule Core.Researcher.Webpages.LinkExtractor do
       String.starts_with?(url, "http") && url != "" && url != "#"
     end)
     |> Stream.reject(&should_skip_url?/1)
-    |> Stream.reject(&is_file_attachment?/1)
+    |> Stream.reject(&file_attachment?/1)
     |> Enum.uniq()
   end
 
@@ -122,15 +122,43 @@ defmodule Core.Researcher.Webpages.LinkExtractor do
     end)
   end
 
-  defp is_file_attachment?(url) do
+  defp file_attachment?(url) do
     file_extensions = [
-      ".jpg", ".jpeg", ".png", ".gif", ".bmp", ".svg", ".webp",
-      ".pdf", ".doc", ".docx", ".xls", ".xlsx", ".ppt", ".pptx",
-      ".zip", ".rar", ".tar", ".gz", ".7z", ".mp3", ".wav", ".ogg",
-      ".mp4", ".mov", ".avi", ".wmv", ".mkv", ".csv", ".txt"
+      ".jpg",
+      ".jpeg",
+      ".png",
+      ".gif",
+      ".bmp",
+      ".svg",
+      ".webp",
+      ".pdf",
+      ".doc",
+      ".docx",
+      ".xls",
+      ".xlsx",
+      ".ppt",
+      ".pptx",
+      ".zip",
+      ".rar",
+      ".tar",
+      ".gz",
+      ".7z",
+      ".mp3",
+      ".wav",
+      ".ogg",
+      ".mp4",
+      ".mov",
+      ".avi",
+      ".wmv",
+      ".mkv",
+      ".csv",
+      ".txt"
     ]
 
     lowercase_url = String.downcase(url)
-    Enum.any?(file_extensions, fn ext -> String.ends_with?(lowercase_url, ext) end)
+
+    Enum.any?(file_extensions, fn ext ->
+      String.ends_with?(lowercase_url, ext)
+    end)
   end
 end

--- a/priv/repo/migrations/20250605143855_add_homepage_scraped_to_companies.exs
+++ b/priv/repo/migrations/20250605143855_add_homepage_scraped_to_companies.exs
@@ -1,0 +1,17 @@
+defmodule Core.Repo.Migrations.AddHomepageScrapedToCompanies do
+  use Ecto.Migration
+
+  def change do
+    up do
+      alter table(:companies) do
+        add :homepage_scraped, :boolean, default: false, null: false
+      end
+    end
+
+    down do
+      alter table(:companies) do
+        remove :homepage_scraped
+      end
+    end
+  end
+end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `homepage_scraped` field to `Company` schema and update enrichment logic to use it, with function renames and logging improvements.
> 
>   - **Schema Changes**:
>     - Add `homepage_scraped` boolean field to `Company` schema in `company.ex`.
>     - Migration `20250605143855_add_homepage_scraped_to_companies.exs` adds `homepage_scraped` to `companies` table.
>   - **Enrichment Logic**:
>     - Update `CompanyEnrich` to set `homepage_scraped` to true after successful scraping.
>     - Modify enrichment functions in `CompanyEnricher` to check `homepage_scraped` before proceeding.
>   - **Function Renames**:
>     - Rename `update_homepage_content` to `set_homepage_scraped` in `company_enrich.ex`.
>     - Rename `is_webpage_content_type` to `webpage_content_type?` in `scraper.ex`.
>     - Rename `is_file_attachment?` to `file_attachment?` in `link_extractor.ex`.
>   - **Miscellaneous**:
>     - Add `:name` to logger metadata in `config.exs`.
>     - Update error logging in `content_processor.ex` and `company_enrich.ex`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for 72f7fb5be7ab5bed8efd7a184171764262ac426a. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->