### PR TITLE
patch: bring embedded trace id to slack

### DIFF
--- a/lib/core/notifications/slack.ex
+++ b/lib/core/notifications/slack.ex
@@ -414,8 +414,7 @@ defmodule Core.Notifications.Slack do
       :mfa,
       :erl_level,
       :otel_span_id,
-      :otel_trace_flags,
-      :otel_trace_id
+      :otel_trace_flags
     ]
 
     custom_metadata =

--- a/lib/core/researcher/scraper.ex
+++ b/lib/core/researcher/scraper.ex
@@ -298,6 +298,7 @@ defmodule Core.Researcher.Scraper do
   end
 
   @unprocessable_indicators [
+    "403 Forbidden",
     "403",
     "Forbidden",
     "Robot Challenge",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove `:otel_trace_id` from Slack metadata and add "403 Forbidden" to unprocessable indicators in scraper.
> 
>   - **Slack Notifications**:
>     - Removed `:otel_trace_id` from metadata keys in `slack.ex`.
>   - **Scraper**:
>     - Added "403 Forbidden" to `@unprocessable_indicators` in `scraper.ex`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for 48f1cdcc656c8ad88eeed71407c6ec6784e78b91. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->