### PR TITLE
patch: add document migration for empty lexical state

### DIFF
--- a/lib/core/crm/documents/document.ex
+++ b/lib/core/crm/documents/document.ex
@@ -63,7 +63,7 @@ defmodule Core.Crm.Documents.Document do
 
   def update_changeset(document, attrs) do
     document
-    |> cast(attrs, [:id, :name, :icon, :color])
+    |> cast(attrs, [:id, :name, :icon, :color, :lexical_state])
     |> validate_required([:id, :name, :icon, :color])
   end
 


### PR DESCRIPTION
- Implemented a new function to migrate documents with empty lexical_state by converting their body content to lexical state and initializing the YDoc.
- Updated the document changeset to include lexical_state in the attributes for updates.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds migration for documents with empty `lexical_state` and updates changeset to include `lexical_state`.
> 
>   - **Migration**:
>     - Adds `migrate_documents_lexical_state()` in `documents.ex` to convert `body` to `lexical_state` for documents with empty `lexical_state` and initialize YDoc.
>   - **Changeset Update**:
>     - Updates `update_changeset()` in `document.ex` to include `lexical_state` in attributes for updates.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for 9c21ea0d19f33aae9fd2d74fbc92f042919a9a00. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->