### PR TITLE
patch: if url is not scrapebale do not mark it as error

### DIFF
--- a/lib/core/researcher/scraper/filter.ex
+++ b/lib/core/researcher/scraper/filter.ex
@@ -155,10 +155,7 @@ defmodule Researcher.Scraper.Filter do
 
     Enum.any?(path_segments, fn segment ->
       segment_lower = String.downcase(segment)
-
-      Enum.any?(excluded_segments, fn excluded ->
-        String.contains?(segment_lower, excluded)
-      end)
+      Enum.any?(excluded_segments, fn excluded -> segment_lower == excluded end)
     end)
   end
 

--- a/lib/core/utils/tracing.ex
+++ b/lib/core/utils/tracing.ex
@@ -58,10 +58,8 @@ defmodule Core.Utils.Tracing do
         :ok
 
       _ctx ->
-        OpenTelemetry.Tracer.set_status(:error, reason_str)
-
         OpenTelemetry.Tracer.set_attributes([
-          {"error.reason", reason_str}
+          {"warning.reason", reason_str}
         ])
     end
   end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Improve handling of non-scrapeable URLs by logging warnings instead of errors and refine URL filtering logic.
> 
>   - **Behavior**:
>     - In `scraper.ex`, `scrape_webpage/1` now logs a warning instead of an error for non-scrapeable URLs (`:should_not_scrape`).
>     - Updated `validate_url/1` to return `{:error, :should_not_scrape}` for non-scrapeable URLs.
>   - **Tracing**:
>     - In `tracing.ex`, `warning/3` now sets `warning.reason` attribute instead of `error.reason`.
>   - **Filter Logic**:
>     - In `filter.ex`, `contains_excluded_segments?/1` now checks for exact matches of excluded segments instead of substring matches.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for 8aca375081fdb39328027f8993510c7db47c7130. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->