### PR TITLE
Alex/cos 7214 multi node cron lockingscheduling

### DIFF
--- a/lib/core/crm/companies/company_enrich.ex
+++ b/lib/core/crm/companies/company_enrich.ex
@@ -225,7 +225,7 @@ defmodule Core.Crm.Companies.CompanyEnrich do
              fetch_company_for_enrichment(company_id, "industry"),
            :ok <- validate_industry_eligibility(company),
            :ok <- mark_industry_attempt(company_id),
-           {:ok, industry_code} <- get_industry_from_ai(company),
+           {:ok, industry_code} <- get_industry_code_from_ai(company),
            {:ok, industry} <- lookup_industry(industry_code, company),
            :ok <- update_company_industry(company_id, industry) do
         :ok
@@ -262,7 +262,7 @@ defmodule Core.Crm.Companies.CompanyEnrich do
     end
   end
 
-  defp get_industry_from_ai(company) do
+  defp get_industry_code_from_ai(company) do
     case get_homepage_content(company.primary_domain) do
       {:ok, homepage_content} ->
         case Enrichment.Industry.identify(%{

--- a/lib/core/utils/cron/cron_lock.ex
+++ b/lib/core/utils/cron/cron_lock.ex
@@ -1,0 +1,42 @@
+defmodule Core.Utils.Cron.CronLock do
+  @moduledoc """
+  Schema module for managing cron job locking.
+
+  This schema represents a locking mechanism for cron jobs to prevent
+  multiple instances of the same job from running simultaneously.
+  It tracks which cron jobs are currently locked and when they were locked.
+  """
+
+  use Ecto.Schema
+
+  @cron_names [
+    :cron_company_domain_processor,
+    :cron_company_enricher,
+    :cron_session_closer
+  ]
+
+  @type cron_name :: unquote(Enum.reduce(@cron_names, &{:|, [], [&1, &2]}))
+
+  @type t :: %__MODULE__{
+          id: integer() | nil,
+          cron_name: cron_name(),
+          lock: String.t() | nil,
+          locked_at: DateTime.t() | nil,
+          inserted_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+
+  schema "cron_locking" do
+    field(:cron_name, Ecto.Enum, values: @cron_names)
+    field(:lock, :string)
+    field(:locked_at, :utc_datetime)
+
+    timestamps()
+  end
+
+  @doc """
+  Returns the list of valid cron names.
+  """
+  @spec valid_cron_names() :: [cron_name()]
+  def valid_cron_names, do: @cron_names
+end

--- a/lib/core/utils/cron_locks.ex
+++ b/lib/core/utils/cron_locks.ex
@@ -16,7 +16,7 @@ defmodule Core.Utils.CronLocks do
   @doc """
   Registers a cron job in the locking system if it doesn't exist.
 
-  This function is idempotentm it will not fail if the cron job is already registered.
+  This function is idempotent; it will not fail if the cron job is already registered.
   It should be called during application startup to ensure all cron jobs are registered.
   """
   @spec register_cron(CronLock.cron_name()) ::

--- a/lib/core/utils/cron_locks.ex
+++ b/lib/core/utils/cron_locks.ex
@@ -1,0 +1,163 @@
+defmodule Core.Utils.CronLocks do
+  @moduledoc """
+  Functions for managing cron job locks.
+
+  This module provides operations for registering and managing cron job locks,
+  ensuring that only one instance of each cron job can run at a time.
+  """
+
+  require Logger
+  alias Core.Repo
+  alias Core.Utils.Cron.CronLock
+  import Ecto.Query
+
+  @valid_cron_names CronLock.valid_cron_names()
+
+  @doc """
+  Registers a cron job in the locking system if it doesn't exist.
+
+  This function is idempotentm it will not fail if the cron job is already registered.
+  It should be called during application startup to ensure all cron jobs are registered.
+  """
+  @spec register_cron(CronLock.cron_name()) ::
+          :ok | {:error, :invalid_cron_name}
+  def register_cron(cron_name) when cron_name in @valid_cron_names do
+    case Repo.insert(
+           %CronLock{cron_name: cron_name},
+           on_conflict: :nothing,
+           conflict_target: :cron_name
+         ) do
+      {:ok, _cron_lock} ->
+        :ok
+
+      {:error, _changeset} ->
+        Logger.error("Failed to register cron job: #{cron_name}")
+        :ok
+    end
+  end
+
+  def register_cron(invalid_name) do
+    Logger.error(
+      "Attempted to register invalid cron name: #{inspect(invalid_name)}"
+    )
+
+    {:error, :invalid_cron_name}
+  end
+
+  @doc """
+  Attempts to acquire a lock for a cron job.
+
+  The lock will only be acquired if the cron job is not currently locked.
+  Returns the updated cron lock record if the lock was acquired, nil otherwise.
+
+  ## Examples
+
+      iex> acquire_lock(:cron_company_enricher, "123e4567-e89b-12d3-a456-426614174000")
+      %CronLock{...}  # Lock acquired
+      nil  # Lock not acquired
+  """
+  @spec acquire_lock(CronLock.cron_name(), String.t()) :: CronLock.t() | nil
+  def acquire_lock(cron_name, lock_uuid) when cron_name in @valid_cron_names do
+    # First try to find and update the record in a single query
+    # This ensures atomicity of the lock acquisition
+    query =
+      from c in CronLock,
+        where: c.cron_name == ^cron_name,
+        where: is_nil(c.lock) or c.lock == "",
+        update: [set: [lock: ^lock_uuid, locked_at: ^DateTime.utc_now()]],
+        select: c
+
+    case Repo.update_all(query, []) do
+      {1, [cron_lock]} ->
+        # Lock was acquired
+        cron_lock
+
+      {0, []} ->
+        # No lock was acquired (either record doesn't exist or is already locked)
+        nil
+    end
+  end
+
+  def acquire_lock(invalid_name, _lock_uuid) do
+    Logger.error(
+      "Attempted to acquire lock for invalid cron name: #{inspect(invalid_name)}"
+    )
+
+    nil
+  end
+
+  @doc """
+  Attempts to release a lock for a cron job.
+
+  The lock will only be released if the provided UUID matches the current lock.
+  This ensures that only the process that acquired the lock can release it.
+
+  ## Examples
+
+      iex> release_lock(:cron_company_enricher, "123e4567-e89b-12d3-a456-426614174000")
+      :ok  # Lock released
+      :error  # Lock not released (UUID mismatch or no lock)
+  """
+  @spec release_lock(CronLock.cron_name(), String.t()) :: :ok | :error
+  def release_lock(cron_name, lock_uuid) when cron_name in @valid_cron_names do
+    # Only release if the UUID matches
+    query =
+      from c in CronLock,
+        where: c.cron_name == ^cron_name,
+        where: c.lock == ^lock_uuid,
+        update: [set: [lock: nil, locked_at: nil]]
+
+    case Repo.update_all(query, []) do
+      {1, _} -> :ok
+      {0, _} -> :error
+    end
+  end
+
+  def release_lock(invalid_name, _lock_uuid) do
+    Logger.error(
+      "Attempted to release lock for invalid cron name: #{inspect(invalid_name)}"
+    )
+
+    :error
+  end
+
+  @doc """
+  Forcefully releases a stuck cron job lock if it's older than the specified duration.
+
+  ## Examples
+
+      iex> force_release_stuck_lock(:cron_company_enricher, 30)
+      :ok  # Lock released if it was older than 30 minutes
+      :error  # No stuck lock found or lock was too recent
+  """
+  @spec force_release_stuck_lock(CronLock.cron_name(), pos_integer()) :: :ok | :error
+  def force_release_stuck_lock(cron_name, max_duration_minutes)
+      when cron_name in @valid_cron_names and max_duration_minutes > 0 do
+
+    cutoff_time = DateTime.add(DateTime.utc_now(), -max_duration_minutes * 60)
+
+    query =
+      from c in CronLock,
+        where: c.cron_name == ^cron_name,
+        where: not is_nil(c.lock),
+        where: c.locked_at < ^cutoff_time,
+        update: [set: [lock: nil, locked_at: nil]]
+
+    case Repo.update_all(query, []) do
+      {1, _} ->
+        Logger.info("Force released stuck lock for cron job: #{cron_name} (older than #{max_duration_minutes} minutes)")
+        :ok
+      {0, _} ->
+        Logger.info("No stuck lock found for cron job: #{cron_name} (older than #{max_duration_minutes} minutes)")
+        :error
+    end
+  end
+
+  def force_release_stuck_lock(invalid_name, _max_duration_minutes) do
+    Logger.error(
+      "Attempted to force release stuck lock for invalid cron name: #{inspect(invalid_name)}"
+    )
+
+    :error
+  end
+end

--- a/lib/core/web_tracker/session_closer.ex
+++ b/lib/core/web_tracker/session_closer.ex
@@ -7,12 +7,16 @@ defmodule Core.WebTracker.SessionCloser do
   require OpenTelemetry.Tracer
   alias Core.WebTracker.Sessions
   alias Core.Utils.Tracing
+  alias Core.Utils.CronLocks
+  alias Core.Utils.Cron.CronLock
 
   # 2 minutes
   @default_interval_ms 2 * 60 * 1000
-  # 5 seconds
-  @short_interval_ms 5 * 1000
+  # 15 seconds
+  @short_interval_ms 15 * 1000
   @default_batch_size 100
+  # Duration in minutes after which a lock is considered stuck
+  @stuck_lock_duration_minutes 30
 
   def start_link(opts \\ []) do
     enabled = Application.get_env(:core, :crons)[:enabled] || false
@@ -27,6 +31,8 @@ defmodule Core.WebTracker.SessionCloser do
 
   @impl true
   def init(_opts) do
+    CronLocks.register_cron(:cron_session_closer)
+
     schedule_check(@default_interval_ms)
 
     {:ok, %{}}
@@ -35,43 +41,65 @@ defmodule Core.WebTracker.SessionCloser do
   @impl true
   def handle_info(:check_sessions, state) do
     OpenTelemetry.Tracer.with_span "web_session_closer.check_sessions" do
-      sessions = Sessions.get_sessions_to_close(@default_batch_size)
-      session_count = length(sessions)
+      lock_uuid = Ecto.UUID.generate()
 
-      OpenTelemetry.Tracer.set_attributes([
-        {"sessions.found", session_count},
-        {"batch.size", @default_batch_size}
-      ])
+      case CronLocks.acquire_lock(:cron_session_closer, lock_uuid) do
+        %CronLock{} ->
+          # Lock acquired, proceed with processing
+          sessions = Sessions.get_sessions_to_close(@default_batch_size)
+          session_count = length(sessions)
 
-      # Close each session and log the result
-      results = Enum.map(sessions, &close_session/1)
+          OpenTelemetry.Tracer.set_attributes([
+            {"sessions.found", session_count},
+            {"batch.size", @default_batch_size}
+          ])
 
-      # Count successes and failures
-      {success_count, failure_count} =
-        Enum.reduce(results, {0, 0}, fn
-          {:ok, _}, {success, failure} -> {success + 1, failure}
-          {:error, _}, {success, failure} -> {success, failure + 1}
-        end)
+          # Close each session and log the result
+          results = Enum.map(sessions, &close_session/1)
 
-      OpenTelemetry.Tracer.set_attributes([
-        {"sessions.closed", success_count},
-        {"sessions.failed", failure_count}
-      ])
+          # Count successes and failures
+          {success_count, failure_count} =
+            Enum.reduce(results, {0, 0}, fn
+              {:ok, _}, {success, failure} -> {success + 1, failure}
+              {:error, _}, {success, failure} -> {success, failure + 1}
+            end)
 
-      # Set span status based on results
-      if failure_count > 0 do
-        Tracing.error("some_sessions_failed_to_close")
-      else
-        Tracing.ok()
+          OpenTelemetry.Tracer.set_attributes([
+            {"sessions.closed", success_count},
+            {"sessions.failed", failure_count}
+          ])
+
+          # Set span status based on results
+          if failure_count > 0 do
+            Tracing.error("some_sessions_failed_to_close")
+          else
+            Tracing.ok()
+          end
+
+          # Release the lock after processing
+          CronLocks.release_lock(:cron_session_closer, lock_uuid)
+
+          # Choose interval based on whether we hit the batch size
+          next_interval_ms =
+            if session_count == @default_batch_size,
+              do: @short_interval_ms,
+              else: @default_interval_ms
+
+          schedule_check(next_interval_ms)
+
+        nil ->
+          # Lock not acquired, try to force release if stuck
+          Logger.info("Session closer lock not acquired, attempting to release any stuck locks")
+
+          case CronLocks.force_release_stuck_lock(:cron_session_closer, @stuck_lock_duration_minutes) do
+            :ok ->
+              Logger.info("Successfully released stuck lock, will retry acquisition on next run")
+            :error ->
+              Logger.info("No stuck lock found or could not release it")
+          end
+
+          schedule_check(@default_interval_ms)
       end
-
-      # Choose interval based on whether we hit the batch size
-      next_interval_ms =
-        if session_count == @default_batch_size,
-          do: @short_interval_ms,
-          else: @default_interval_ms
-
-      schedule_check(next_interval_ms)
 
       {:noreply, state}
     end

--- a/lib/core/web_tracker/web_tracker.ex
+++ b/lib/core/web_tracker/web_tracker.ex
@@ -279,7 +279,7 @@ defmodule Core.WebTracker do
 
         case ip_intelligence_mod.get_company_info(ip) do
           {:ok, %{domain: domain, company: company}} ->
-            process_company_info(domain, company, tenant, session_id)
+            process_company_data(domain, company, tenant, session_id)
 
           {:error, reason} ->
             Tracing.error(reason, "Failed to get company info",
@@ -290,12 +290,12 @@ defmodule Core.WebTracker do
     end
   end
 
-  defp process_company_info(domain, nil, _tenant, _session_id) do
+  defp process_company_data(domain, nil, _tenant, _session_id) do
     Logger.warning("Company not found for domain", company_domain: domain)
   end
 
-  defp process_company_info(domain, company_ip_intelligence, tenant, session_id) do
-    OpenTelemetry.Tracer.with_span "web_tracker.process_company_info" do
+  defp process_company_data(domain, company_ip_intelligence, tenant, session_id) do
+    OpenTelemetry.Tracer.with_span "web_tracker.process_company_data" do
       OpenTelemetry.Tracer.set_attributes([
         {"company.domain", domain},
         {"company.name", company_ip_intelligence.name},
@@ -353,11 +353,7 @@ defmodule Core.WebTracker do
         {:error, reason} ->
           Tracing.error(reason, "Company not created from webTracker",
             company: company_ip_intelligence.name,
-            company_domain: domain,
-            trace_id:
-              :otel_span.trace_id(OpenTelemetry.Tracer.current_span_ctx())
-              |> Integer.to_string(16)
-              |> String.downcase()
+            company_domain: domain
           )
       end
     end

--- a/priv/repo/migrations/20250607051919_create_table_cron_locking.exs
+++ b/priv/repo/migrations/20250607051919_create_table_cron_locking.exs
@@ -1,0 +1,20 @@
+defmodule Core.Repo.Migrations.CreateTableCronLocking do
+  use Ecto.Migration
+
+  def up do
+    create table(:cron_locking) do
+      add :cron_name, :string, null: false
+      add :lock, :string
+      add :locked_at, :utc_datetime
+
+      timestamps(type: :utc_datetime)
+    end
+
+    # Add unique index on cron_name
+    create unique_index(:cron_locking, [:cron_name])
+  end
+
+  def down do
+    drop table(:cron_locking)
+  end
+end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Introduces cron job locking mechanism with `CronLock` schema and `CronLocks` module, updating GenServers to manage locks and adding a migration for the `cron_locking` table.
> 
>   - **Cron Job Locking**:
>     - Introduces `CronLock` schema in `cron/cron_lock.ex` for managing cron job locks.
>     - Adds `CronLocks` module in `cron_locks.ex` for operations like acquiring, releasing, and force-releasing locks.
>     - Migration `20250607051919_create_table_cron_locking.exs` creates `cron_locking` table with unique `cron_name`.
>   - **GenServer Updates**:
>     - `CompanyDomainProcessor`, `CompanyEnricher`, and `SessionCloser` now acquire and release locks using `CronLocks`.
>     - Handle stuck locks by force-releasing them if older than 30 minutes.
>   - **Function Renames**:
>     - Renames `get_industry_from_ai()` to `get_industry_code_from_ai()` in `company_enrich.ex`.
>     - Renames `process_company_info()` to `process_company_data()` in `web_tracker.ex`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for 6d200679c04727945d5483bdad5cac4f213988ba. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->