### PR TITLE
patch: add bun build scripts to local

### DIFF
--- a/scripts/runners/build-core.sh
+++ b/scripts/runners/build-core.sh
@@ -19,9 +19,11 @@ echo "==> Installing JS dependencies and building Bun scripts..."
 cd scripts
 bun install
 bun build --compile convert_lexical_to_yjs.ts --output convert_lexical_to_yjs
+bun build --compile convert_md_to_lexical.ts --output convert_md_to_lexical
 
 mkdir -p ../priv/scripts
 mv convert_lexical_to_yjs ../priv/scripts/
+mv convert_md_to_lexical ../priv/scripts/
 cd ..
 
 echo "==> Compiling..."


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add build step for `convert_md_to_lexical.ts` in `build-core.sh` to compile and move the output to `priv/scripts`.
> 
>   - **Build Process**:
>     - In `build-core.sh`, add `bun build --compile convert_md_to_lexical.ts --output convert_md_to_lexical` to compile `convert_md_to_lexical.ts`.
>     - Move `convert_md_to_lexical` to `../priv/scripts/` after compilation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for dbaf4f2d170c6a2b937fdfcfe8ec3d1aa8bb5839. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->