### PR TITLE
patch: icp fit evaluator to use cron locks

### DIFF
--- a/lib/core/utils/cron/cron_lock.ex
+++ b/lib/core/utils/cron/cron_lock.ex
@@ -12,7 +12,8 @@ defmodule Core.Utils.Cron.CronLock do
   @cron_names [
     :cron_company_domain_processor,
     :cron_company_enricher,
-    :cron_session_closer
+    :cron_session_closer,
+    :cron_icp_fit_evaluator
   ]
 
   @type cron_name :: unquote(Enum.reduce(@cron_names, &{:|, [], [&1, &2]}))


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds cron lock functionality to `IcpFitEvaluator` to prevent concurrent executions using `CronLocks`.
> 
>   - **Behavior**:
>     - `IcpFitEvaluator` now uses `CronLocks` to acquire and release locks, preventing concurrent executions.
>     - If lock acquisition fails, attempts to release stuck locks using `force_release_stuck_lock()`.
>   - **CronLock Module**:
>     - Adds `:cron_icp_fit_evaluator` to `@cron_names` in `cron_lock.ex`.
>   - **Misc**:
>     - Registers cron job in `init()` of `IcpFitEvaluator`.
>     - Logs lock acquisition and release attempts in `handle_info()` of `IcpFitEvaluator`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for ea1958796a0f6beb5897c63f340df1f97002faa8. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->