### PR TITLE
patch: fix timeout

### DIFF
--- a/lib/core/crm/leads/daily_lead_summary_sender.ex
+++ b/lib/core/crm/leads/daily_lead_summary_sender.ex
@@ -32,7 +32,7 @@ defmodule Core.Crm.Leads.DailyLeadSummarySender do
   # Duration in minutes after which a lock is considered stuck
   @stuck_lock_duration_minutes 30
   # Check every 5 minutes
-  @check_interval_ms 5 * 2 * 1000
+  @check_interval_ms 5 * 60 * 1000
   # Minimum time between executions (23 hours and 30 minutes in seconds)
   @min_execution_interval_seconds 23 * 3600 + 30 * 60
   # Email sender details


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes timeout interval in `DailyLeadSummarySender` to check for stuck locks every 5 minutes.
> 
>   - **Behavior**:
>     - Fixes timeout interval in `DailyLeadSummarySender` by changing `@check_interval_ms` from 10,000 ms to 300,000 ms.
>     - Ensures the system checks for stuck locks every 5 minutes as intended.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for 7f5099efcf2510eb9f975ce08f47ccbdd8513b61. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->