### PR TITLE
patch: slack notfications for icp requests

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -162,7 +162,8 @@ config :core, :slack,
   daily_lead_summary_webhook_url:
     get_env.("SLACK_DAILY_LEAD_SUMMARY_WEBHOOK_URL", nil),
   crash_webhook_url: get_env.("SLACK_CRASH_WEBHOOK_URL", nil),
-  error_webhook_url: get_env.("SLACK_CRASH_WEBHOOK_URL", nil)
+  error_webhook_url: get_env.("SLACK_CRASH_WEBHOOK_URL", nil),
+  alerts_prospects_url: get_env.("SLACK_PROSPECTS_ALERT_URL", nil)
 
 config :core, :mailsherpa,
   mailsherpa_api_url: get_env.("MAILSHERPA_API_URL", nil),

--- a/lib/core/researcher/icp_builder.ex
+++ b/lib/core/researcher/icp_builder.ex
@@ -68,6 +68,10 @@ defmodule Core.Researcher.IcpBuilder do
   end
 
   def build_icp_fast(domain) do
+    Task.start(fn ->
+      Core.Notifications.Slack.notify_new_icp_request(domain)
+    end)
+
     case IcpProfiles.get_by_domain(domain) do
       {:ok, existing_profile} ->
         {:ok, existing_profile}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds Slack notifications for new ICP requests with configuration and implementation changes in `runtime.exs`, `slack.ex`, and `icp_builder.ex`.
> 
>   - **Behavior**:
>     - Adds `notify_new_icp_request/1` in `slack.ex` to send Slack notifications for new ICP requests.
>     - Triggers Slack notification in `build_icp_fast/1` in `icp_builder.ex` when a new ICP request is submitted.
>   - **Configuration**:
>     - Adds `alerts_prospects_url` to Slack configuration in `runtime.exs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for 848496a79f0c1ac24e2f74d5f52c6ede649a2665. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->