### PR TITLE
patch: add IcpProfile type and integrate into Leads header

### DIFF
--- a/assets/src/components/Modal/Modal.tsx
+++ b/assets/src/components/Modal/Modal.tsx
@@ -36,7 +36,7 @@ export const ModalOverlay = forwardRef<HTMLDivElement, DialogOverlayProps>(
       <Dialog.Overlay
         ref={ref}
         className={twMerge(
-          'z-[999] backdrop-brightness-[.55] data-[state=open]:animate-overlayShow fixed inset-0 cursor-pointer overflow-y-auto top-0 left-0 bottom-0 right-0 h-[100vh]',
+          'z-[999] backdrop-brightness-[.55] data-[state=open]:animate-overlayShow fixed inset-0 cursor-pointer overflow-y-auto top-0 left-0 bottom-0 right-0 h-[100vh] backdrop-blur-xs',
           className
         )}
         {...props}

--- a/assets/src/pages/Leads/components/Header/Header.tsx
+++ b/assets/src/pages/Leads/components/Header/Header.tsx
@@ -4,12 +4,12 @@ import { router, usePage } from '@inertiajs/react';
 import { cn } from 'src/utils/cn';
 import { PageProps } from '@inertiajs/core';
 import { Button } from 'src/components/Button';
-import { Lead, User, Tenant } from 'src/types';
 import { Avatar } from 'src/components/Avatar';
 import { Icon } from 'src/components/Icon/Icon';
 import { Tooltip } from 'src/components/Tooltip';
 import { toastSuccess } from 'src/components/Toast';
 import { IconButton } from 'src/components/IconButton';
+import { Lead, User, Tenant, IcpProfile } from 'src/types';
 import { useEventsChannel, LeadCreatedEvent } from 'src/hooks';
 import {
   Modal,
@@ -29,7 +29,7 @@ import { UserPresence } from '../UserPresence/UserPresence';
 export const Header = () => {
   const [createdLeadIcons, setCreatedLeadIcons] = useState<string[]>([]);
   const page = usePage<
-    PageProps & { tenant: Tenant; profile: string; currentUser: User; companies: Lead[] }
+    PageProps & { tenant: Tenant; currentUser: User; companies: Lead[]; profile: IcpProfile }
   >();
   const [isOpen, setIsOpen] = useState(false);
   const [displayProfile, setDisplayProfile] = useState(false);
@@ -91,6 +91,7 @@ export const Header = () => {
               variant="ghost"
               aria-label="icp"
               icon={<Icon name="building-03" />}
+              className="group-hover:opacity-100 opacity-0 transition-opacity duration-300"
               onClick={e => {
                 page.props.profile && setDisplayProfile(true);
                 e.stopPropagation();
@@ -211,10 +212,21 @@ export const Header = () => {
         <ModalPortal>
           <ModalOverlay />
           <ModalContent placement="top" aria-describedby="profile-modal">
-            <ModalHeader className="font-semibold text-base">See who's ready to buy</ModalHeader>
+            <ModalHeader className="font-semibold text-base">
+              <div className="flex flex-col items-start gap-2">
+                <p className="font-semibold">Your Ideal Customer Profile</p>
+                <p className="font-medium text-sm">Description</p>
+              </div>
+            </ModalHeader>
             <ModalCloseButton />
             <ModalBody className="flex flex-col gap-2">
-              <p>{page.props?.profile}</p>
+              <p>{page.props?.profile.profile}</p>
+              <p className="text-sm font-medium">Qualifying criteria</p>
+              <ul className="list-disc pl-4 flex flex-col gap-0 text-sm">
+                {page.props?.profile.qualifyingAttributes?.map(attribute => (
+                  <li key={attribute}>{attribute}</li>
+                ))}
+              </ul>
             </ModalBody>
             <ModalFooter>
               <ModalClose asChild>

--- a/assets/src/types.ts
+++ b/assets/src/types.ts
@@ -44,3 +44,8 @@ export type Document = {
   inserted_at: string;
   lexical_state: string;
 };
+
+export type IcpProfile = {
+  profile: string;
+  qualifyingAttributes: string[];
+};

--- a/lib/core/researcher/icp_profiles.ex
+++ b/lib/core/researcher/icp_profiles.ex
@@ -55,7 +55,11 @@ defmodule Core.Researcher.IcpProfiles do
 
       case Repo.get_by(Profile, tenant_id: tenant_id) do
         %Profile{} = icp ->
-          {:ok, icp}
+          {:ok,
+           %{
+             profile: icp.profile,
+             qualifying_attributes: icp.qualifying_attributes
+           }}
 
         nil ->
           Tracing.error(:not_found)

--- a/lib/web/controllers/leads_controller.ex
+++ b/lib/web/controllers/leads_controller.ex
@@ -16,7 +16,7 @@ defmodule Web.LeadsController do
 
       profile =
         case Core.Researcher.IcpProfiles.get_by_tenant_id(tenant_id) do
-          {:ok, profile} -> Map.get(profile, :profile)
+          {:ok, profile} -> profile
           _ -> nil
         end
 


### PR DESCRIPTION
- Introduced a new IcpProfile type in types.ts to encapsulate profile data and qualifying attributes.
- Updated the Leads header component to utilize the new IcpProfile type, enhancing the profile display in the modal.
- Modified the modal content to present the ideal customer profile and its qualifying criteria more clearly.
- Adjusted the backend to return the complete profile structure for better integration with the frontend.