### PR TITLE
patch: fix icp crash

### DIFF
--- a/lib/core/researcher/icp_fit_evaluator/prompt_builder.ex
+++ b/lib/core/researcher/icp_fit_evaluator/prompt_builder.ex
@@ -25,6 +25,18 @@ defmodule Core.Researcher.IcpFitEvaluator.PromptBuilder do
   def build_prompts(domain, business_pages, icp) do
     {:ok, homepage} = Scraper.scrape_webpage(domain)
 
+    homepage_summary =
+      case homepage do
+        %{summary: summary} when is_binary(summary) ->
+          summary
+
+        %{content: content} ->
+          String.slice(content, 0, 1000) <> "..."
+
+        _ ->
+          "No homepage content available"
+      end
+
     system_prompt = """
       I will provide you with a B2B company and relevant context from their website.  I will also provide you with a description of my business, my ideal customer profile and qualifying criteria.  Your job is to determine how well the company matches my ideal customer profile.  Valid response values are "strong", "moderate", "not a fit".  Please only return one of these three values.
       NOTE: If the company I provide you sells a product or service that is a substitute for my product or service, they are a competitor.  Return "not a fit".
@@ -36,7 +48,7 @@ defmodule Core.Researcher.IcpFitEvaluator.PromptBuilder do
     """
 
     prompt = """
-    About my business: #{homepage["summary"]}
+    About my business: #{homepage_summary}
     My Ideal Customer Profile: #{icp.profile}
     My Qualifying Criteria: #{icp.qualifying_attributes}
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes potential crash in `build_prompts` by handling missing `summary` in `homepage` in `prompt_builder.ex`.
> 
>   - **Behavior**:
>     - Fixes potential crash in `build_prompts` in `prompt_builder.ex` by handling cases where `homepage` lacks a `summary`.
>     - Uses `String.slice` to extract up to 1000 characters from `homepage` content if `summary` is missing.
>     - Defaults to "No homepage content available" if neither `summary` nor `content` is present.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for c72666a53a2674a93c1c69a4037c92a8e33e9ae0. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->