### PR TITLE
patch: fix icp profiles crash

### DIFF
--- a/lib/core/researcher/icp_profiles.ex
+++ b/lib/core/researcher/icp_profiles.ex
@@ -55,11 +55,7 @@ defmodule Core.Researcher.IcpProfiles do
 
       case Repo.get_by(Profile, tenant_id: tenant_id) do
         %Profile{} = icp ->
-          {:ok,
-           %{
-             profile: icp.profile,
-             qualifying_attributes: icp.qualifying_attributes
-           }}
+          {:ok, icp}
 
         nil ->
           Tracing.error(:not_found)

--- a/lib/web/controllers/leads_controller.ex
+++ b/lib/web/controllers/leads_controller.ex
@@ -17,7 +17,7 @@ defmodule Web.LeadsController do
 
       profile =
         case Core.Researcher.IcpProfiles.get_by_tenant_id(tenant_id) do
-          {:ok, profile} -> profile
+          {:ok, icp} -> %{profile: icp.profile, qualifying_attributes: icp.qualifying_attributes}
           _ -> nil
         end
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes crash in ICP profiles by returning full `Profile` struct and updating its handling in `leads_controller.ex`.
> 
>   - **Behavior**:
>     - Fixes crash in `get_by_tenant_id` in `icp_profiles.ex` by returning the full `Profile` struct instead of a map with specific fields.
>     - Updates `index` function in `leads_controller.ex` to handle the new return structure by extracting `profile` and `qualifying_attributes` from the `Profile` struct.
>   - **Misc**:
>     - No changes to other functions or files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for fbd8bb3110dff69153b3ffe40092249c44c41dd5. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->