### PR TITLE
patch: use ip intelligence cache part 1

### DIFF
--- a/lib/core/web_tracker/ip_profiler.ex
+++ b/lib/core/web_tracker/ip_profiler.ex
@@ -48,8 +48,21 @@ defmodule Core.WebTracker.IPProfiler do
   """
   @spec get_company_info(String.t()) :: {:ok, map()} | {:error, term()}
   def get_company_info(ip) when is_binary(ip) do
-    #    // if in db return it otherwise move one
-    IpIdentifier.identify_ip(ip)
+    case IpIntelligence.get_by_ip(ip) do
+      {:ok, %IpIntelligence{domain_source: :snitcher, domain: domain} = record} when not is_nil(domain) ->
+        {:ok, %{
+          ip: record.ip,
+          domain: record.domain,
+          type: "company",
+          company: %{}
+        }}
+
+      {:ok, _} ->
+        IpIdentifier.identify_ip(ip)
+
+      {:error, _} ->
+        IpIdentifier.identify_ip(ip)
+    end
   end
 
   def get_company_info(_), do: {:error, "IP address must be a string"}

--- a/lib/core/web_tracker/web_tracker.ex
+++ b/lib/core/web_tracker/web_tracker.ex
@@ -294,17 +294,16 @@ defmodule Core.WebTracker do
     Logger.warning("Company not found for domain", company_domain: domain)
   end
 
-  defp process_company_data(domain, company_ip_intelligence, tenant, session_id) do
+  defp process_company_data(domain, _company_ip_intelligence, tenant, session_id) do
     OpenTelemetry.Tracer.with_span "web_tracker.process_company_data" do
       OpenTelemetry.Tracer.set_attributes([
         {"company.domain", domain},
-        {"company.name", company_ip_intelligence.name},
         {"tenant", tenant},
         {"session.id", session_id}
       ])
 
       Logger.info(
-        "Found company for domain #{domain}: #{company_ip_intelligence.name}"
+        "Found company for domain #{domain}"
       )
 
       case Companies.get_or_create_by_domain(domain) do
@@ -358,7 +357,6 @@ defmodule Core.WebTracker do
 
         {:error, reason} ->
           Tracing.error(reason, "Company not created from webTracker",
-            company: company_ip_intelligence.name,
             company_domain: domain
           )
       end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Optimize IP intelligence handling by using cached data and simplifying company data processing in `ip_profiler.ex` and `web_tracker.ex`.
> 
>   - **Behavior**:
>     - `get_company_info` in `ip_profiler.ex` now checks `IpIntelligence` cache before calling `IpIdentifier.identify_ip`.
>     - Simplifies `process_company_data` in `web_tracker.ex` by removing `company_ip_intelligence` parameter and related logging.
>   - **Logging**:
>     - Removes logging of `company_ip_intelligence.name` in `web_tracker.ex`.
>     - Adjusts error logging in `process_company_data` in `web_tracker.ex`.
>   - **Misc**:
>     - Minor refactoring in `web_tracker.ex` to streamline company data processing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for c64ad495f0bbc1f8421d04c83d59a8e7918a4ce7. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->