### PR TITLE
patch: fix double login stats on registration

### DIFF
--- a/lib/core/stats/stats.ex
+++ b/lib/core/stats/stats.ex
@@ -12,7 +12,7 @@ defmodule Core.Stats do
 
   ## Parameters
     - user_id: String representing the user identifier
-    - event_type: Atom representing the type of event (:login, :logout, :view_document, :download_document)
+    - event_type: Atom representing the type of event
 
   ## Returns
     - `:ok` immediately, as the operation is performed asynchronously

--- a/lib/web/controllers/signin_controller.ex
+++ b/lib/web/controllers/signin_controller.ex
@@ -45,8 +45,6 @@ defmodule Web.AuthController do
       %User{} = user ->
         {:ok, user} = Users.confirm_user(user)
 
-        Stats.register_event_start(user.id, :login)
-
         conn
         |> put_flash(:info, "Logged in successfully.")
         |> Web.UserAuth.signup_user(user)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes double login event registration by removing redundant call in `signup_with_token` in `signin_controller.ex`.
> 
>   - **Behavior**:
>     - Removes redundant `Stats.register_event_start(user.id, :login)` call in `signup_with_token` in `signin_controller.ex` to prevent double login event registration.
>   - **Docs**:
>     - Updates `@doc` in `stats.ex` to remove specific event types from the description.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for 86d00ec22ea7967de089dbb9a63ce841158e8b42. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->