### PR TITLE
patch: clean up error handling

### DIFF
--- a/lib/core/utils/cron_locks.ex
+++ b/lib/core/utils/cron_locks.ex
@@ -13,6 +13,8 @@ defmodule Core.Utils.CronLocks do
 
   @valid_cron_names CronLock.valid_cron_names()
 
+  @err_invalid_cron_name {:error, "invalid cron name"}
+
   @doc """
   Registers a cron job in the locking system if it doesn't exist.
 
@@ -41,7 +43,7 @@ defmodule Core.Utils.CronLocks do
       "Attempted to register invalid cron name: #{inspect(invalid_name)}"
     )
 
-    {:error, :invalid_cron_name}
+    @err_invalid_cron_name
   end
 
   @doc """

--- a/lib/core/utils/url_formatter.ex
+++ b/lib/core/utils/url_formatter.ex
@@ -12,15 +12,12 @@ defmodule Core.Utils.UrlFormatter do
     input = String.trim(input)
 
     cond do
-      # Already has https://
       String.starts_with?(input, "https://") ->
         {:ok, input}
 
-      # Has http:// - convert to https://
       String.starts_with?(input, "http://") ->
         {:ok, String.replace_prefix(input, "http://", "https://")}
 
-      # No protocol - add https://
       true ->
         {:ok, "https://#{input}"}
     end
@@ -50,11 +47,9 @@ defmodule Core.Utils.UrlFormatter do
 
     case String.split(url, "?", parts: 2) do
       [base_url] ->
-        # No query parameters
         {:ok, base_url, %{}}
 
       [base_url, query_string] ->
-        # Parse query parameters
         query_params = parse_query_string(query_string)
         {:ok, base_url, query_params}
     end
@@ -94,7 +89,6 @@ defmodule Core.Utils.UrlFormatter do
     end
   end
 
-  # Private helper to parse query string into a map
   defp parse_query_string(query_string) do
     query_string
     |> String.split("&")


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor error handling in `cron_locks.ex`, `dns_resolver.ex`, and `url_formatter.ex` by using predefined error tuples for consistency.
> 
>   - **Error Handling**:
>     - Introduce predefined error tuples in `cron_locks.ex`, `dns_resolver.ex`, and `url_formatter.ex` for consistent error handling.
>     - Replace direct error returns with predefined error tuples in `get_dns`, `get_mx_records`, `get_spf_record`, `get_cname_record`, and `has_a_or_aaaa_record` in `dns_resolver.ex`.
>     - Use predefined error tuples in `to_https`, `strip_query_params`, `get_base_url`, and `get_query_params` in `url_formatter.ex`.
>   - **Misc**:
>     - Remove redundant type specifications in `dns_resolver.ex` for functions `get_dns`, `get_mx_records`, `get_spf_record`, `get_cname_record`, and `has_a_or_aaaa_record`.
>     - Remove unnecessary comments in `url_formatter.ex` for clarity.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for e52b2eb70d9fb2442f9eeb0e404e273f1fba74ea. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->