### PR TITLE
patch: add retry logic to icp builder

### DIFF
--- a/lib/core/utils/task_awaiter.ex
+++ b/lib/core/utils/task_awaiter.ex
@@ -1,0 +1,12 @@
+defmodule Core.Utils.TaskAwaiter do
+  @err_timeout {:error, :timeout}
+
+  def await(task, timeout) do
+    case Task.yield(task, timeout) do
+      {:ok, {:ok, response}} -> {:ok, response}
+      {:ok, {:error, reason}} -> {:error, reason}
+      {:exit, reason} -> {:error, reason}
+      nil -> @err_timeout
+    end
+  end
+end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds retry logic to ICP builder and related modules, refactoring code to use new retry and task awaiter utilities for improved robustness.
> 
>   - **Behavior**:
>     - Adds retry logic to `tenant_icp` in `icp_builder.ex` using `build_icp_with_retry()`.
>     - Implements retry logic in `get_primary_domain()` in `primary_domain_finder.ex` using `Retry.with_delay()`.
>     - Refactors `crawl_website_with_retry()` and `get_icp_fit_with_retry()` in `icp_fit_evaluator.ex` to use `TaskAwaiter.await()`.
>   - **Utilities**:
>     - Introduces `Retry.with_delay()` in `retry.ex` for retrying function calls with delay.
>     - Adds `TaskAwaiter.await()` in `task_awaiter.ex` for task management with timeout handling.
>   - **Misc**:
>     - Replaces `call_with_delayed_retry()` with `with_delay()` in `primary_domain_finder.ex` and `retry.ex`.
>     - Adds logging for retry attempts and task awaiting in `retry.ex` and `task_awaiter.ex`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for ba85477632f5171b4533e54a5d39ed07b177f999. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->