### PR TITLE
patch: fix company name crashes

### DIFF
--- a/lib/core/crm/companies/company_enrich.ex
+++ b/lib/core/crm/companies/company_enrich.ex
@@ -374,11 +374,19 @@ defmodule Core.Crm.Companies.CompanyEnrich do
             OpenTelemetry.Tracer.set_attributes([{"ai.name", name}])
             {:ok, name}
 
-          {:error, reason, name} ->
+          {:error, reason, name} when is_binary(name) and name != "" ->
             Tracing.error(reason, "Rejected company name from AI",
               company_id: company.id,
               company_domain: company.primary_domain,
               name: name
+            )
+
+            {:error, reason}
+
+          {:error, reason, _} ->
+            Tracing.error(reason, "AI name identification failed",
+              company_id: company.id,
+              company_domain: company.primary_domain
             )
 
             {:error, reason}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Improves error handling in `get_name_from_ai()` in `company_enrich.ex` by adding a guard clause and handling empty or non-binary names.
> 
>   - **Error Handling**:
>     - In `company_enrich.ex`, `get_name_from_ai()` now handles `{:error, reason, _}` by logging "AI name identification failed" and returning `{:error, reason}`.
>     - Adds a guard clause to `{:error, reason, name}` to ensure `name` is a non-empty binary before logging "Rejected company name from AI".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for 8b59e93160ad1789dc0fd150072646c4bc830edd. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->