### PR TITLE
patch: fix unwrapped tuple

### DIFF
--- a/lib/core/utils/domainIO.ex
+++ b/lib/core/utils/domainIO.ex
@@ -19,7 +19,7 @@ defmodule Core.Utils.DomainIO do
            test_redirect_call(url)
          end)
          |> TaskAwaiter.await(@resolve_timeout_ms) do
-      {:ok, result} -> result
+      {:ok, result} -> {:ok, result}
       {:error, reason} -> {:error, reason}
     end
   end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes return value in `test_redirect` function in `domainIO.ex` to ensure result is wrapped in a tuple.
> 
>   - **Behavior**:
>     - Fixes return value in `test_redirect` function in `domainIO.ex` to ensure result is wrapped in a tuple `{:ok, result}` instead of just `result`.
>   - **Misc**:
>     - No other changes or refactors in the code.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for 1d5de578d67d2fdfda02d8300155ff97571aa7ac. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->