### PR TITLE
patch: do not report image not found as error

### DIFF
--- a/lib/core/crm/companies/company_enrich.ex
+++ b/lib/core/crm/companies/company_enrich.ex
@@ -32,7 +32,7 @@ defmodule Core.Crm.Companies.CompanyEnrich do
   @err_not_found {:error, "not found"}
   @err_update_failed {:error, "update failed"}
   @err_invalid_request {:error, "invalid request"}
-  @err_image_not_found {:error, "image not found"}
+  @err_image_not_found {:error, :image_not_found}
   @err_empty_ai_response {:error, "empty ai response"}
   @err_scrape_not_needed {:error, "scrape not needed"}
   @err_industry_not_found {:error, "industry not found"}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change `@err_image_not_found` to use an atom instead of a string for error handling in `company_enrich.ex`.
> 
>   - **Error Handling**:
>     - Change `@err_image_not_found` from `{:error, "image not found"}` to `{:error, :image_not_found}` in `company_enrich.ex`.
>     - Affects error handling in `download_company_icon/1` function.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for 1881b4b9a5731eac3e5b73d92accd768ba1c3af9. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->