### PR TITLE
patch: add cluster release config

### DIFF
--- a/rel/vm.args.eex
+++ b/rel/vm.args.eex
@@ -1,0 +1,15 @@
+## Set the node name from the environment. The deployment script provides this.
+-sname ${NODE_NAME}
+
+## Set the cookie for distribution from the environment.
+-setcookie ${COOKIE}
+
+## Enable kernel poll and set a short tick time
++K true
++A 5
+
+## Increase number of concurrent ports
++P 1048576
+
+## Pass all arguments from the entrypoint script to the Erlang VM
+${RELEASE_EXTRA_ARGS}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `rel/vm.args.eex` for Erlang VM configuration, setting node name, cookie, kernel poll, tick time, concurrent ports, and extra arguments.
> 
>   - **Configuration**:
>     - New `rel/vm.args.eex` file for Erlang VM configuration.
>     - Sets node name with `-sname ${NODE_NAME}` and cookie with `-setcookie ${COOKIE}`.
>     - Enables kernel poll with `+K true` and sets tick time with `+A 5`.
>     - Increases concurrent ports with `+P 1048576`.
>     - Passes extra arguments with `${RELEASE_EXTRA_ARGS}`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for d9b9504d66415aff41d6f54f9048525178d631c1. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->