### PR TITLE
patch: move deploy to own workflow

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -43,15 +43,6 @@ jobs:
           curl -fsSL https://bun.sh/install | bash
           echo "$HOME/.bun/bin" >> $GITHUB_PATH
 
-      - name: Install Janet from source
-        run: |
-          wget https://github.com/janet-lang/janet/releases/download/v1.38.0/janet-v1.38.0-linux-x64.tar.gz
-          tar -xzf janet-v1.38.0-linux-x64.tar.gz
-          cd janet-v1.38.0-linux-x64
-          sudo cp janet /usr/local/bin/
-          sudo chmod +x /usr/local/bin/janet
-          janet -v
-
       - name: Build Phoenix app
         run: |
           ./scripts/runners/build-core.sh ${{ env.APP_PATH }}
@@ -84,8 +75,3 @@ jobs:
           token: ${{ secrets.CLOUD_REPO_KEY }}
           path: cloud
           fetch-depth: 1
-
-      - name: Run deploy script
-        run: |
-          cd cloud/core
-          ./deploy.janet ${{ env.VERSION }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -44,6 +44,7 @@ jobs:
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             VERSION="${{ github.event.inputs.version }}"
           else
+            # Get the tag that triggered the original workflow
             VERSION=$(git describe --tags --exact-match ${{ github.event.workflow_run.head_sha }} 2>/dev/null || echo "")
             if [ -z "$VERSION" ]; then
               echo "Could not determine version from workflow_run"
@@ -53,18 +54,20 @@ jobs:
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           echo "Deploying version: $VERSION"
 
-      - name: Install Janet from source
+      - name: Install Janet
         run: |
-          wget https://github.com/janet-lang/janet/releases/download/v1.38.0/janet-v1.38.0-linux-x64.tar.gz
-          tar -xzf janet-v1.38.0-linux-x64.tar.gz
-          cd janet-v1.38.0-linux-x64
-          sudo cp janet /usr/local/bin/
-          sudo chmod +x /usr/local/bin/janet
-          if [ -f jpm ]; then
-            sudo cp jpm /usr/local/bin/
-            sudo chmod +x /usr/local/bin/jpm
-          fi
-          janet -v
+          sudo apt update
+          sudo apt install -y build-essential git
+
+          export PREFIX="$HOME/.local"
+          mkdir -p "$PREFIX/bin"
+
+          git clone https://github.com/janet-lang/janet.git
+          cd janet
+          make -j
+          make test
+          make install
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: Checkout cloud repo
         uses: actions/checkout@v4


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Move deploy steps to a new `deploy.yaml` workflow, separating it from the build process.
> 
>   - **Workflows**:
>     - Move deploy steps from `build-image.yaml` to a new `deploy.yaml` workflow.
>     - `deploy.yaml` triggers on completion of `Build Image` workflow or manually via `workflow_dispatch`.
>   - **Installations**:
>     - Change Janet installation method in `deploy.yaml` to build from source using `git clone` and `make`.
>     - Remove Janet installation from `build-image.yaml`.
>   - **Misc**:
>     - Add comment in `deploy.yaml` for extracting version from tag.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for 19461d1b52c43deaef6c089e6fa5ca8c25d632be. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->