### PR TITLE
patch: fix unique page visits

### DIFF
--- a/lib/core/researcher/brief_writer/engagement_profiler.ex
+++ b/lib/core/researcher/brief_writer/engagement_profiler.ex
@@ -139,9 +139,7 @@ defmodule Core.Researcher.BriefWriter.EngagementProfiler do
   defp get_unique_page_visits(events) do
     unique_visits =
       events
-      |> Enum.flat_map(fn item ->
-        if item.href, do: [UrlFormatter.get_base_url(item.href)], else: []
-      end)
+      |> Enum.map(&UrlFormatter.get_base_url/1)
       |> Enum.uniq()
 
     {:ok, unique_visits}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Simplifies `get_unique_page_visits` in `engagement_profiler.ex` by using `Enum.map` for extracting base URLs, maintaining unique visit functionality.
> 
>   - **Behavior**:
>     - Simplifies `get_unique_page_visits` in `engagement_profiler.ex` by replacing `Enum.flat_map` with `Enum.map`.
>     - Directly maps `events` to base URLs using `UrlFormatter.get_base_url/1`.
>     - Retains functionality of returning unique page visits.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for 6512e7d5d9c62b6a50c79a125f23835830230575. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->