### PR TITLE
patch: sync hubspot companies

### DIFF
--- a/lib/application.ex
+++ b/lib/application.ex
@@ -28,6 +28,7 @@ defmodule Core.Application do
       Core.Crm.Companies.CompanyDomainProcessor,
       Core.Crm.Leads.IcpFitEvaluator,
       Core.Crm.Leads.DailyLeadSummarySender,
+      Core.Integrations.Providers.HubSpot.CompaniesSyncJob,
       Core.WebTracker.SessionCloser,
       Core.Crm.Industries,
       Web.Endpoint,

--- a/lib/core/integrations/connection/connection.ex
+++ b/lib/core/integrations/connection/connection.ex
@@ -39,6 +39,8 @@ defmodule Core.Integrations.Connection do
           expires_at: DateTime.t(),
           scopes: [String.t()] | nil,
           connection_error: String.t() | nil,
+          company_sync_after: String.t() | nil,
+          company_sync_completed: boolean(),
           inserted_at: DateTime.t(),
           updated_at: DateTime.t()
         }
@@ -65,6 +67,9 @@ defmodule Core.Integrations.Connection do
     field(:scopes, {:array, :string})
     field(:connection_error, :string)
 
+    field(:company_sync_after, :string)
+    field(:company_sync_completed, :boolean)
+
     timestamps(type: :utc_datetime)
   end
 
@@ -86,7 +91,9 @@ defmodule Core.Integrations.Connection do
       :token_type,
       :expires_at,
       :scopes,
-      :connection_error
+      :connection_error,
+      :company_sync_after,
+      :company_sync_completed
     ])
     |> validate_required([
       :id,

--- a/lib/core/integrations/providers/hubspot/companies_sync_job.ex
+++ b/lib/core/integrations/providers/hubspot/companies_sync_job.ex
@@ -15,7 +15,7 @@ defmodule Core.Integrations.Providers.HubSpot.CompaniesSyncJob do
   # 5 minutes
   @default_interval_ms 5 * 60 * 1000
   # 10 companies
-  @default_batch_size_per_hubspot_instance 10
+  @default_batch_size_per_hubspot_instance 50
   # Duration in minutes after which a lock is considered stuck
   @stuck_lock_duration_minutes 30
 
@@ -47,7 +47,6 @@ defmodule Core.Integrations.Providers.HubSpot.CompaniesSyncJob do
 
       case CronLocks.acquire_lock(:cron_hubspot_company_sync, lock_uuid) do
         %CronLock{} ->
-
           process_hubspot_connections()
 
           CronLocks.release_lock(:cron_hubspot_company_sync, lock_uuid)
@@ -91,7 +90,7 @@ defmodule Core.Integrations.Providers.HubSpot.CompaniesSyncJob do
         fetch_hubspot_connections()
 
       OpenTelemetry.Tracer.set_attributes([
-        {"connections.found", length(hubspot_connections)},
+        {"connections.found", length(hubspot_connections)}
       ])
 
       Enum.each(hubspot_connections, &sync_hubspot_connection/1)
@@ -102,16 +101,21 @@ defmodule Core.Integrations.Providers.HubSpot.CompaniesSyncJob do
   defp sync_hubspot_connection(hubspot_connection) do
     OpenTelemetry.Tracer.with_span "hubspot.companies_job.sync_hubspot_connection" do
       params = %{
-        limit: @default_batch_size_per_hubspot_instance,
+        limit: @default_batch_size_per_hubspot_instance
       }
 
-      final_params = if hubspot_connection.company_sync_after do
-        Map.put(params, :after, hubspot_connection.company_sync_after)
-      else
-        params
-      end
+      final_params =
+        if hubspot_connection.company_sync_after do
+          Map.put(params, :after, hubspot_connection.company_sync_after)
+        else
+          params
+        end
 
-      Core.Integrations.Providers.HubSpot.Companies.sync_companies(hubspot_connection.id, final_params, false)
+      Core.Integrations.Providers.HubSpot.Companies.sync_companies(
+        hubspot_connection.id,
+        final_params,
+        false
+      )
     end
   end
 

--- a/lib/core/integrations/providers/hubspot/companies_sync_job.ex
+++ b/lib/core/integrations/providers/hubspot/companies_sync_job.ex
@@ -1,0 +1,125 @@
+defmodule Core.Integrations.Providers.HubSpot.CompaniesSyncJob do
+  @moduledoc """
+  GenServer responsible for syncing HubSpot companies.
+  """
+  use GenServer
+  require Logger
+  require OpenTelemetry.Tracer
+  import Ecto.Query
+
+  alias Core.Repo
+  alias Core.Utils.CronLocks
+  alias Core.Utils.Cron.CronLock
+  alias Core.Integrations.Connection
+
+  # 5 minutes
+  @default_interval_ms 5 * 60 * 1000
+  # 10 companies
+  @default_batch_size_per_hubspot_instance 10
+  # Duration in minutes after which a lock is considered stuck
+  @stuck_lock_duration_minutes 30
+
+  def start_link(opts \\ []) do
+    crons_enabled = Application.get_env(:core, :crons)[:enabled] || false
+
+    if crons_enabled do
+      GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+    else
+      Logger.info("HubSpot companies sync job is disabled (crons disabled)")
+      :ignore
+    end
+  end
+
+  @impl true
+  def init(_opts) do
+    CronLocks.register_cron(:cron_hubspot_company_sync)
+
+    # Schedule the first check
+    schedule_check(@default_interval_ms)
+
+    {:ok, %{}}
+  end
+
+  @impl true
+  def handle_info(:sync_companies, state) do
+    OpenTelemetry.Tracer.with_span "hubspot.companies_job.sync_companies" do
+      lock_uuid = Ecto.UUID.generate()
+
+      case CronLocks.acquire_lock(:cron_hubspot_company_sync, lock_uuid) do
+        %CronLock{} ->
+
+          process_hubspot_connections()
+
+          CronLocks.release_lock(:cron_hubspot_company_sync, lock_uuid)
+
+          schedule_check(@default_interval_ms)
+
+        nil ->
+          # Lock not acquired, try to force release if stuck
+          Logger.info(
+            "HubSpot companies sync job lock not acquired, attempting to release any stuck locks"
+          )
+
+          case CronLocks.force_release_stuck_lock(
+                 :cron_hubspot_company_sync,
+                 @stuck_lock_duration_minutes
+               ) do
+            :ok ->
+              Logger.info(
+                "Successfully released stuck lock, will retry acquisition on next run"
+              )
+
+            :error ->
+              Logger.info("No stuck lock found or could not release it")
+          end
+
+          schedule_check(@default_interval_ms)
+      end
+
+      {:noreply, state}
+    end
+  end
+
+  # Schedule the next check
+  defp schedule_check(interval_ms) do
+    Process.send_after(self(), :sync_companies, interval_ms)
+  end
+
+  defp process_hubspot_connections() do
+    OpenTelemetry.Tracer.with_span "hubspot.companies_job.process_hubspot_connections" do
+      hubspot_connections =
+        fetch_hubspot_connections()
+
+      OpenTelemetry.Tracer.set_attributes([
+        {"connections.found", length(hubspot_connections)},
+      ])
+
+      Enum.each(hubspot_connections, &sync_hubspot_connection/1)
+      {:ok, length(hubspot_connections)}
+    end
+  end
+
+  defp sync_hubspot_connection(hubspot_connection) do
+    OpenTelemetry.Tracer.with_span "hubspot.companies_job.sync_hubspot_connection" do
+      params = %{
+        limit: @default_batch_size_per_hubspot_instance,
+      }
+
+      final_params = if hubspot_connection.company_sync_after do
+        Map.put(params, :after, hubspot_connection.company_sync_after)
+      else
+        params
+      end
+
+      Core.Integrations.Providers.HubSpot.Companies.sync_companies(hubspot_connection.id, final_params, false)
+    end
+  end
+
+  defp fetch_hubspot_connections() do
+    Connection
+    |> where([c], c.provider == :hubspot)
+    |> where([c], c.company_sync_completed == false)
+    |> limit(@default_batch_size_per_hubspot_instance)
+    |> Repo.all()
+  end
+end

--- a/lib/core/researcher/icp_fit_evaluator/prompt_builder.ex
+++ b/lib/core/researcher/icp_fit_evaluator/prompt_builder.ex
@@ -23,22 +23,23 @@ defmodule Core.Researcher.IcpFitEvaluator.PromptBuilder do
   end
 
   def build_prompts(domain, business_pages, icp) do
-    homepage_summary = case Scraper.scrape_webpage(domain) do
-      {:ok, homepage} ->
-        case homepage do
-          %{summary: summary} when is_binary(summary) ->
-            summary
+    homepage_summary =
+      case Scraper.scrape_webpage(domain) do
+        {:ok, homepage} ->
+          case homepage do
+            %{summary: summary} when is_binary(summary) ->
+              summary
 
-          %{content: content} ->
-            String.slice(content, 0, 1000) <> "..."
+            %{content: content} ->
+              String.slice(content, 0, 1000) <> "..."
 
-          _ ->
-            "No homepage content available"
-        end
+            _ ->
+              "No homepage content available"
+          end
 
-      {:error, _reason} ->
-        "Unable to scrape homepage content"
-    end
+        {:error, _reason} ->
+          "Unable to scrape homepage content"
+      end
 
     system_prompt = """
       I will provide you with a B2B company and relevant context from their website.  I will also provide you with a description of my business, my ideal customer profile and qualifying criteria.  Your job is to determine how well the company matches my ideal customer profile.  Valid response values are "strong", "moderate", "not a fit".  Please only return one of these three values.

--- a/lib/core/utils/cron/cron_lock.ex
+++ b/lib/core/utils/cron/cron_lock.ex
@@ -16,7 +16,8 @@ defmodule Core.Utils.Cron.CronLock do
     :cron_company_scrapin_enricher,
     :cron_session_closer,
     :cron_icp_fit_evaluator,
-    :cron_daily_lead_summary_sender
+    :cron_daily_lead_summary_sender,
+    :cron_hubspot_company_sync
   ]
 
   @type cron_name :: unquote(Enum.reduce(@cron_names, &{:|, [], [&1, &2]}))

--- a/lib/core/utils/primary_domain_finder.ex
+++ b/lib/core/utils/primary_domain_finder.ex
@@ -34,7 +34,8 @@ defmodule Core.Utils.PrimaryDomainFinder do
   @err_invalid_ssl {:error, "ssl certificate error"}
   @err_dns_lookup_failed {:error, "dns lookup failed"}
   @err_circular_domain {:error, "circular domain reference"}
-  @err_cannot_resolve_to_primary_domain {:error, :cannot_resolve_to_primary_domain}
+  @err_cannot_resolve_to_primary_domain {:error,
+                                         :cannot_resolve_to_primary_domain}
 
   # Configuration constants
   @max_retries 3

--- a/priv/repo/migrations/20250623144344_add_company_sync_after_to_integration_connections.exs
+++ b/priv/repo/migrations/20250623144344_add_company_sync_after_to_integration_connections.exs
@@ -1,0 +1,17 @@
+defmodule Core.Repo.Migrations.AddCompanySyncAfterToIntegrationConnections do
+  use Ecto.Migration
+
+  def up do
+    alter table(:integration_connections) do
+      add :company_sync_after, :string
+      add :company_sync_completed, :boolean, default: false, null: false
+    end
+  end
+
+  def down do
+    alter table(:integration_connections) do
+      remove :company_sync_after
+      remove :company_sync_completed
+    end
+  end
+end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds HubSpot company sync feature with new GenServer job, schema changes, and updated sync logic.
> 
>   - **New Feature**:
>     - Adds `CompaniesSyncJob` GenServer in `companies_sync_job.ex` to periodically sync HubSpot companies.
>     - Introduces `sync_companies/3` in `companies.ex` for paginated company data synchronization.
>   - **Schema Changes**:
>     - Adds `company_sync_after` and `company_sync_completed` fields to `Connection` schema in `connection.ex`.
>     - Migration `20250623144344_add_company_sync_after_to_integration_connections.exs` adds new fields to `integration_connections` table.
>   - **Behavior Changes**:
>     - Updates `sync_company/2` in `companies.ex` to handle archived, non-customer, and invalid domain cases.
>     - Removes async company sync initiation from `HubspotController`.
>   - **Misc**:
>     - Adds `:cron_hubspot_company_sync` to `CronLock` in `cron_lock.ex`.
>     - Refactors `build_prompts/3` in `prompt_builder.ex` for better readability.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for ba9a5d33a7109fb0f4d637a8612101856c892af3. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->