### PR TITLE
patch: fix setting icp fit on hubspot sync

### DIFF
--- a/lib/core/integrations/providers/hubspot/companies.ex
+++ b/lib/core/integrations/providers/hubspot/companies.ex
@@ -341,7 +341,7 @@ defmodule Core.Integrations.Providers.HubSpot.Companies do
          is_customer
        ) do
     if is_customer and lead.stage != :customer do
-      case Core.Crm.Leads.update_lead(lead, %{stage: :customer}) do
+      case Core.Crm.Leads.update_lead(lead, %{stage: :customer, icp_fit: :strong}) do
         {:ok, updated_lead} -> {:ok, updated_lead}
         {:error, reason} -> {:error, reason}
       end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes `update_lead_stage_for_customer` in `companies.ex` to set `icp_fit: :strong` when updating lead stage to `:customer`.
> 
>   - **Behavior**:
>     - Fixes `update_lead_stage_for_customer` in `companies.ex` to set `icp_fit: :strong` when updating lead stage to `:customer`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for 80b53aa40c7812f4173106d3c7742281e522b8ec. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->