### PR TITLE
patch: skip warning on not a customer

### DIFF
--- a/lib/web/controllers/hubspot_webhook_controller.ex
+++ b/lib/web/controllers/hubspot_webhook_controller.ex
@@ -70,6 +70,11 @@ defmodule Web.HubspotWebhookController do
           "[HubspotWebhookController] Processed event: #{inspect(event)}"
         )
 
+      {:error, :not_customer} ->
+        Logger.info(
+          "[HubspotWebhookController] Not a customer: #{inspect(event)}"
+        )
+
       {:error, reason} ->
         Logger.error(
           "[HubspotWebhookController] Failed to process event: #{inspect(reason)}"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds handling for `{:error, :not_customer}` in `process_single_event` to log an info message in `hubspot_webhook_controller.ex`.
> 
>   - **Behavior**:
>     - Adds handling for `{:error, :not_customer}` in `process_single_event` in `hubspot_webhook_controller.ex`, logging an info message instead of a warning.
>   - **Logging**:
>     - Logs "Not a customer" info message when `{:error, :not_customer}` occurs in `process_single_event`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for 4191cfa5fc612d41c2156b5191c302d47414e866. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->