### PR TITLE
patch: introduce stage not a fit

### DIFF
--- a/lib/core/crm/leads.ex
+++ b/lib/core/crm/leads.ex
@@ -201,8 +201,10 @@ defmodule Core.Crm.Leads do
       query_leads_view()
       |> where([l], l.tenant_id == ^tenant_id)
       |> where([l], l.type == :company)
-      |> where([l], l.stage not in [:not_a_fit, :pending])
+      |> where([l], l.stage not in [:not_a_fit, :pending]) # TODO alexb remove not a fit
+      |> where([l], not is_nil(l.stage))
       |> where([l], not is_nil(l.icp_fit))
+      |> where([l], l.icp_fit != :not_a_fit)
       |> order(order_by)
       |> Repo.all()
       |> then(fn

--- a/lib/core/crm/leads/icp_fit_evaluator.ex
+++ b/lib/core/crm/leads/icp_fit_evaluator.ex
@@ -152,7 +152,7 @@ defmodule Core.Crm.Leads.IcpFitEvaluator do
     Lead
     |> where([l], l.type == :company)
     |> where([l], is_nil(l.icp_fit))
-    |> where([l], l.stage != :not_a_fit)
+    |> where([l], l.stage != :not_a_fit) # TODO alexb remove condition
     |> where([l], l.icp_fit_evaluation_attempts < ^max_attempts)
     |> where(
       [l],

--- a/lib/core/crm/leads/lead.ex
+++ b/lib/core/crm/leads/lead.ex
@@ -23,7 +23,7 @@ defmodule Core.Crm.Leads.Lead do
           | :ready_to_buy
           | :customer
           | :not_a_fit
-  @type icp_fit :: :strong | :moderate | :not_a_fit,
+  @type icp_fit :: :strong | :moderate | :not_a_fit
   @type t :: %__MODULE__{
           id: String.t(),
           tenant_id: String.t(),

--- a/lib/core/crm/leads/lead.ex
+++ b/lib/core/crm/leads/lead.ex
@@ -23,7 +23,7 @@ defmodule Core.Crm.Leads.Lead do
           | :ready_to_buy
           | :customer
           | :not_a_fit
-  @type icp_fit :: :strong | :moderate
+  @type icp_fit :: :strong | :moderate | :not_a_fit,
   @type t :: %__MODULE__{
           id: String.t(),
           tenant_id: String.t(),
@@ -43,7 +43,7 @@ defmodule Core.Crm.Leads.Lead do
     field(:tenant_id, :string)
     field(:ref_id, :string)
     field(:type, Ecto.Enum, values: [:contact, :company])
-    field(:icp_fit, Ecto.Enum, values: [:strong, :moderate])
+    field(:icp_fit, Ecto.Enum, values: [:strong, :moderate, :not_a_fit])
 
     field(:stage, Ecto.Enum,
       values: [

--- a/lib/core/researcher/icp_fit_evaluator.ex
+++ b/lib/core/researcher/icp_fit_evaluator.ex
@@ -99,7 +99,7 @@ defmodule Core.Researcher.IcpFitEvaluator do
           Leads.update_lead(lead, %{icp_fit: :moderate, stage: :target})
 
         :not_a_fit ->
-          Leads.update_lead(lead, %{stage: :not_a_fit})
+          Leads.update_lead(lead, %{icp_fit: :not_a_fit, stage: :not_a_fit})
       end
     end
   end

--- a/lib/core/web_tracker/session_analyzer.ex
+++ b/lib/core/web_tracker/session_analyzer.ex
@@ -75,6 +75,7 @@ defmodule Core.WebTracker.SessionAnalyzer do
            Leads.get_by_ref_id(tenant.id, company_id) do
       cond do
         lead.stage == :ready_to_buy -> {:stop, :already_ready_to_buy}
+        lead.icp_fit == :not_a_fit -> {:stop, :not_icp_fit}
         lead.stage == :not_a_fit -> {:stop, :not_icp_fit}
         true -> {:ok, :proceed}
       end

--- a/lib/web/channels/events_channel.ex
+++ b/lib/web/channels/events_channel.ex
@@ -15,15 +15,6 @@ defmodule Web.Channels.EventsChannel do
   use Web, :channel
   require Logger
 
-  @event_types [
-    :login,
-    :logout,
-    :view_document,
-    :download_document,
-    :set_up_tracker,
-    :book_a_call
-  ]
-
   @impl true
   def join("events:" <> tenant_id, _payload, socket) do
     Logger.info("joined events channel :: #{tenant_id}")

--- a/lib/web/controllers/leads_controller.ex
+++ b/lib/web/controllers/leads_controller.ex
@@ -136,6 +136,7 @@ defmodule Web.LeadsController do
       :customer -> "Customer"
       :not_a_fit -> "Not a Fit"
       :pending -> "Pending"
+      nil -> ""
       _ -> stage |> Atom.to_string() |> String.capitalize()
     end
   end

--- a/priv/repo/migrations/20250624163806_update_icp_fit_enum.exs
+++ b/priv/repo/migrations/20250624163806_update_icp_fit_enum.exs
@@ -1,0 +1,19 @@
+defmodule Core.Repo.Migrations.UpdateIcpFitEnum do
+  use Ecto.Migration
+
+  def up do
+    execute("""
+    ALTER TYPE icp_fit ADD VALUE 'not_a_fit'
+    """)
+  end
+
+  def down do
+    # Note: PostgreSQL doesn't support removing enum values directly
+    # This would require recreating the enum type, which is complex
+    # and potentially dangerous in production
+    execute("""
+    -- Cannot safely remove enum values in PostgreSQL
+    -- Manual intervention required if rollback is needed
+    """)
+  end
+end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `:not_a_fit` to `icp_fit` enum and update logic across modules to handle this new value, including a database migration.
> 
>   - **Behavior**:
>     - Adds `:not_a_fit` to `icp_fit` enum in `lead.ex` and updates related logic in `leads.ex`, `icp_fit_evaluator.ex`, and `session_analyzer.ex`.
>     - Updates `list_view_by_tenant_id()` in `leads.ex` to filter out leads with `icp_fit` as `:not_a_fit`.
>     - Updates `evaluate_lead()` in `icp_fit_evaluator.ex` to set `icp_fit` to `:not_a_fit` when applicable.
>     - Updates `ok_to_run()` in `session_analyzer.ex` to stop processing if `icp_fit` is `:not_a_fit`.
>   - **Migration**:
>     - Adds migration `20250624163806_update_icp_fit_enum.exs` to add `:not_a_fit` to `icp_fit` enum in the database.
>   - **Misc**:
>     - Removes unused `@event_types` in `events_channel.ex`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for b0d7d2e9af0f2d52d63458dc9cf08aa859e12040. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->