### PR TITLE
patch: fix leads table stage column

### DIFF
--- a/priv/repo/migrations/20250624185446_set_stage_nullable_in_leads.exs
+++ b/priv/repo/migrations/20250624185446_set_stage_nullable_in_leads.exs
@@ -1,0 +1,15 @@
+defmodule Core.Repo.Migrations.SetStageNullableInLeads do
+  use Ecto.Migration
+
+  def up do
+    alter table(:leads) do
+      modify :stage, :lead_stage, null: true, default: "pending"
+    end
+  end
+
+  def down do
+    alter table(:leads) do
+      modify :stage, :lead_stage, null: false, default: "pending"
+    end
+  end
+end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add migration to make `stage` column in `leads` table nullable with default "pending".
> 
>   - **Migration**:
>     - Adds `20250624185446_set_stage_nullable_in_leads.exs` to make `stage` column in `leads` table nullable with default "pending".
>     - `down` function reverts `stage` column to non-nullable with default "pending".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for 6c5f59a32d5d1981cb2d82c83d48a6aac354e3be. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->