### PR TITLE
patch: brief retry script

### DIFF
--- a/lib/core/crm/companies/company_enrich.ex
+++ b/lib/core/crm/companies/company_enrich.ex
@@ -666,7 +666,6 @@ defmodule Core.Crm.Companies.CompanyEnrich do
         else
           @err_timeout
         end
-        @err_timeout
 
       {:error, "HTTP request failed with status 500"} ->
         Tracing.warning(:http_error, "HTTP request failed with status 500")

--- a/lib/core/crm/companies/company_enrich.ex
+++ b/lib/core/crm/companies/company_enrich.ex
@@ -661,7 +661,11 @@ defmodule Core.Crm.Companies.CompanyEnrich do
 
       {:error, :timeout} ->
         Tracing.warning(:timeout, "Fetching company icon timed out")
-
+        if company.icon_enrichment_attempts >= 2 do
+          download_company_logo(company)
+        else
+          @err_timeout
+        end
         @err_timeout
 
       {:error, "HTTP request failed with status 500"} ->

--- a/lib/core/crm/leads.ex
+++ b/lib/core/crm/leads.ex
@@ -437,10 +437,12 @@ defmodule Core.Crm.Leads do
 
     Lead
     |> where([l], l.inserted_at < ^thirty_minutes_ago)
-    |> where([l], l.stage not in [:pending])
+    |> where([l], l.stage not in [:pending, :customer])
+    |> where([l], not is_nil(l.stage))
     |> where([l], l.icp_fit in [:strong, :moderate])
     |> join(:left, [l], rd in "refs_documents", on: rd.ref_id == l.id)
     |> where([l, rd], is_nil(rd.ref_id))
+    |> order_by([l], desc: l.inserted_at)
     |> limit(^limit)
     |> Repo.all()
     |> then(fn

--- a/scripts/production/brief_creator.exs
+++ b/scripts/production/brief_creator.exs
@@ -88,5 +88,5 @@ defmodule BriefCreator do
   end
 end
 
-# Run the script with default limit of 10
-BriefCreator.run_all(200)
+# Run the script
+BriefCreator.run_all(5)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Improves retry logic for company icon downloads and refines lead filtering, with a script adjustment for processing limits.
> 
>   - **Behavior**:
>     - In `company_enrich.ex`, retry logic for downloading company icons is improved by attempting to download the company logo if icon enrichment attempts are 2 or more.
>     - In `leads.ex`, the `get_icp_fits_without_brief_docs` function now excludes leads with `:customer` stage and orders results by `inserted_at`.
>   - **Scripts**:
>     - In `brief_creator.exs`, the default limit for `run_all` is changed from 200 to 5.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for 340fbb65690f08c1afb435c8f53a250482c0f0a0. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->