### PR TITLE
patch: do not report errors on brief writer

### DIFF
--- a/lib/core/researcher/brief_writer.ex
+++ b/lib/core/researcher/brief_writer.ex
@@ -33,6 +33,10 @@ defmodule Core.Researcher.BriefWriter do
         engagement_summary
       )
     else
+      {:error, :closed_sessions_not_found} ->
+        Tracing.warning(:closed_sessions_not_found, "Closed sessions not available, skipping brief creation")
+        {:error, :closed_sessions_not_found}
+
       {:error, reason} ->
         Logger.error("Account Brief failed: #{inspect(reason)}",
           tenant_id: tenant_id,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds specific error handling and logging for `:closed_sessions_not_found` in `BriefWriter.create_brief`.
> 
>   - **Error Handling**:
>     - In `BriefWriter.create_brief`, adds handling for `{:error, :closed_sessions_not_found}`.
>     - Logs a warning with `Tracing.warning` instead of an error for `:closed_sessions_not_found`.
>   - **Logging**:
>     - Adds a specific log message for `:closed_sessions_not_found` indicating brief creation is skipped.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for f2ddd8ae5db5cfc166d6f05e0bffa658ad56fbf6. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->