### PR TITLE
patch: remove homepage content from companies table

### DIFF
--- a/lib/core/auth/users.ex
+++ b/lib/core/auth/users.ex
@@ -125,7 +125,8 @@ defmodule Core.Auth.Users do
         customeros_tenant_name =
           Application.get_env(:core, :customeros)[:customeros_tenant_name]
 
-        {:ok, customeros_tenant} = Tenants.get_tenant_by_name(customeros_tenant_name)
+        {:ok, customeros_tenant} =
+          Tenants.get_tenant_by_name(customeros_tenant_name)
 
         if customeros_tenant.domain == domain do
           changeset

--- a/lib/core/crm/companies/company.ex
+++ b/lib/core/crm/companies/company.ex
@@ -52,9 +52,6 @@ defmodule Core.Crm.Companies.Company do
     field(:linkedin_id, :string)
     field(:linkedin_alias, :string)
 
-    # Scraped content
-    # home page
-    field(:homepage_content, :string)
     field(:homepage_scraped, :boolean, default: false)
 
     # Quantitative fields
@@ -91,11 +88,8 @@ defmodule Core.Crm.Companies.Company do
           icon_enrichment_attempts: integer(),
           business_model_enrichment_attempts: integer(),
           scrapin_enrichment_attempts: integer(),
-          # LinkedIn fields
           linkedin_id: String.t() | nil,
           linkedin_alias: String.t() | nil,
-          # Scraped content
-          homepage_content: String.t() | nil,
           homepage_scraped: boolean(),
           # Quantitative fields
           technologies_used: {:array, :string},
@@ -135,7 +129,6 @@ defmodule Core.Crm.Companies.Company do
       :scrapin_enrichment_attempts,
       :linkedin_id,
       :linkedin_alias,
-      :homepage_content,
       :homepage_scraped,
       :technologies_used,
       :city,

--- a/lib/core/crm/companies/company_enrich.ex
+++ b/lib/core/crm/companies/company_enrich.ex
@@ -58,7 +58,7 @@ defmodule Core.Crm.Companies.CompanyEnrich do
            :ok <- validate_scrape_eligibility(company),
            :ok <- mark_scrape_attempt(company_id),
            {:ok, content} <- scrape_company_homepage(company),
-           :ok <- set_homepage_scraped(company_id, content) do
+           :ok <- set_homepage_scraped(company_id) do
         trigger_enrichment_tasks(company_id)
         :ok
       else
@@ -166,10 +166,10 @@ defmodule Core.Crm.Companies.CompanyEnrich do
     end
   end
 
-  defp set_homepage_scraped(company_id, content) do
+  defp set_homepage_scraped(company_id) do
     case Repo.update_all(
            from(c in Company, where: c.id == ^company_id),
-           set: [homepage_content: content, homepage_scraped: true]
+           set: [homepage_scraped: true]
          ) do
       {0, _} ->
         Tracing.error(:update_failed, "Failed to update homepage for company",

--- a/lib/core/crm/companies/company_enricher.ex
+++ b/lib/core/crm/companies/company_enricher.ex
@@ -247,7 +247,6 @@ defmodule Core.Crm.Companies.CompanyEnricher do
 
     Company
     |> where([c], is_nil(c.industry_code) or c.industry_code == "")
-    |> where([c], not is_nil(c.homepage_content) and c.homepage_content != "")
     |> where([c], c.homepage_scraped == true)
     |> where([c], c.industry_enrichment_attempts < ^max_attempts)
     |> where(
@@ -364,7 +363,6 @@ defmodule Core.Crm.Companies.CompanyEnricher do
 
     Company
     |> where([c], is_nil(c.name) or c.name == "")
-    |> where([c], not is_nil(c.homepage_content) and c.homepage_content != "")
     |> where([c], c.homepage_scraped == true)
     |> where([c], c.name_enrichment_attempts < ^max_attempts)
     |> where(
@@ -421,7 +419,6 @@ defmodule Core.Crm.Companies.CompanyEnricher do
 
     Company
     |> where([c], is_nil(c.country_a2) or c.country_a2 == "")
-    |> where([c], not is_nil(c.homepage_content) and c.homepage_content != "")
     |> where([c], c.homepage_scraped == true)
     |> where([c], c.country_enrichment_attempts < ^max_attempts)
     |> where(

--- a/lib/core/web_tracker/bot_detector.ex
+++ b/lib/core/web_tracker/bot_detector.ex
@@ -135,7 +135,9 @@ defmodule Core.WebTracker.BotDetector do
     has_high_confidence_signal = Enum.any?(signals, &(&1.weight == 1.0))
 
     # Determine if it's a bot based on confidence threshold OR high confidence signal
-    is_bot = has_high_confidence_signal or confidence > BotDetectorConfig.confidence_threshold()
+    is_bot =
+      has_high_confidence_signal or
+        confidence > BotDetectorConfig.confidence_threshold()
 
     {is_bot, min(confidence, 1.0), signals}
   end

--- a/priv/repo/migrations/20250627122821_remove_homepage_content_from_companies.exs
+++ b/priv/repo/migrations/20250627122821_remove_homepage_content_from_companies.exs
@@ -1,0 +1,15 @@
+defmodule Core.Repo.Migrations.RemoveHomepageContentFromCompanies do
+  use Ecto.Migration
+
+  def up do
+    alter table(:companies) do
+      remove(:homepage_content)
+    end
+  end
+
+  def down do
+    alter table(:companies) do
+      add(:homepage_content, :text)
+    end
+  end
+end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove `homepage_content` field from `companies` table and update related code and queries.
> 
>   - **Database Migration**:
>     - Adds migration `20250627122821_remove_homepage_content_from_companies.exs` to remove `homepage_content` from `companies` table.
>   - **Schema Changes**:
>     - Removes `homepage_content` field from `Company` schema in `company.ex`.
>   - **Function Modifications**:
>     - Updates `set_homepage_scraped/1` in `company_enrich.ex` to no longer set `homepage_content`.
>     - Removes `homepage_content` conditions from queries in `company_enricher.ex`.
>   - **Miscellaneous**:
>     - Minor formatting changes in `users.ex` and `bot_detector.ex`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for c17eca9f29c034a2eaa28d548823b05b8cf4f98a. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->