### PR TITLE
patch: change bot-detect endpoint to POST and update request handling

### DIFF
--- a/lib/web/controllers/web_tracker_controller.ex
+++ b/lib/web/controllers/web_tracker_controller.ex
@@ -62,11 +62,10 @@ defmodule Web.WebTrackerController do
     end
   end
 
-  def bot_detect(conn, _params) do
+  def bot_detect(conn, %{"ip" => ip}) do
     OpenTelemetry.Tracer.with_span "web_tracker_controller.bot_detect" do
       user_agent = get_req_header(conn, "user-agent") |> List.first() || ""
       origin = get_req_header(conn, "origin") |> List.first() || ""
-      ip = get_req_header(conn, "ip") |> List.first() || ""
       referrer = get_req_header(conn, "referrer") |> List.first() || ""
 
       OpenTelemetry.Tracer.set_attributes([

--- a/lib/web/router.ex
+++ b/lib/web/router.ex
@@ -146,7 +146,7 @@ defmodule Web.Router do
     pipe_through :cors_event_api
 
     post "/events", WebTrackerController, :create
-    get "/events/bot-detect", WebTrackerController, :bot_detect
+    post "/events/bot-detect", WebTrackerController, :bot_detect
   end
 
   # ICP endpoint with CORS

--- a/priv/static/scripts/analytics-0.1.js
+++ b/priv/static/scripts/analytics-0.1.js
@@ -1,11 +1,12 @@
 (function (w) {
   function botd(ip) {
     return fetch("{{CDN_ENDPOINT}}/b", {
-      headers: {
-        "user-agent": navigator.userAgent,
-        origin: window.location.origin,
+      method: "POST",
+      body: JSON.stringify({
         ip: ip,
-        referrer: document.referrer,
+      }),
+      headers: {
+        "Content-Type": "application/json",
       },
     })
       .then((botd) => botd.json())


### PR DESCRIPTION
- Updated the router to change the bot-detect endpoint from GET to POST.
- Modified the bot_detect function to accept IP from request parameters instead of headers.
- Adjusted the analytics script to send a POST request with JSON body containing the IP.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change `bot-detect` endpoint to POST, update request handling to accept IP from body, and modify analytics script to send IP in JSON body.
> 
>   - **Behavior**:
>     - Change `bot-detect` endpoint in `router.ex` from GET to POST.
>     - Update `bot_detect` in `web_tracker_controller.ex` to accept IP from request body.
>     - Modify `analytics-0.1.js` to send POST request with JSON body containing IP.
>   - **Misc**:
>     - Remove IP extraction from headers in `bot_detect` function.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for 98832b3fdb304f47f8fba847e0fd2fcf75b26f2b. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->