### PR TITLE
patch: Api for target persona creation

### DIFF
--- a/lib/core/crm/contacts.ex
+++ b/lib/core/crm/contacts.ex
@@ -513,12 +513,11 @@ defmodule Core.Crm.Contacts do
     end
   end
 
-  defp process_avatar_for_contact(contact, photo_url) do
-    # Skip if contact already has avatar
-    if not is_nil(contact.avatar_key) do
-      {:ok, contact}
-    else
+  defp process_avatar_for_contact(%Contact{} = contact, photo_url) do
+    if is_nil(contact.avatar_key) do
       process_avatar_for_contact_without_avatar(contact, photo_url)
+    else
+      {:ok, contact}
     end
   end
 

--- a/lib/core/crm/target_personas.ex
+++ b/lib/core/crm/target_personas.ex
@@ -9,8 +9,8 @@ defmodule Core.Crm.TargetPersonas do
   alias Core.Utils.Tracing
   alias Core.Auth.Tenants
 
-  @err_persona_creation_failed {:error, "target persona creation failed"}
-  @err_tenant_not_found {:error, "tenant not found"}
+  @err_persona_creation_failed {:error, :target_persona_creation_failed}
+  @err_tenant_not_found {:error, :tenant_not_found}
 
   def create_from_linkedin(tenant_id, linkedin_url) do
     OpenTelemetry.Tracer.with_span "target_personas.create_from_linkedin" do

--- a/lib/core/web_tracker/sessions/paid_campaign.ex
+++ b/lib/core/web_tracker/sessions/paid_campaign.ex
@@ -93,8 +93,7 @@ defmodule Core.WebTracker.Sessions.PaidCampaign do
             get_field(changeset, :targeting_id),
             get_field(changeset, :content_id)
           ]
-          |> Enum.map(&(&1 || ""))
-          |> Enum.join("|")
+          |> Enum.map_join("|", &(&1 || ""))
 
         hash = :crypto.hash(:sha256, hash_input) |> Base.encode16(case: :lower)
         put_change(changeset, :hash, hash)

--- a/lib/core/web_tracker/sessions/utm_campaign.ex
+++ b/lib/core/web_tracker/sessions/utm_campaign.ex
@@ -107,8 +107,7 @@ defmodule Core.WebTracker.Sessions.UtmCampaign do
             get_field(changeset, :utm_term),
             get_field(changeset, :utm_content)
           ]
-          |> Enum.map(&(&1 || ""))
-          |> Enum.join("|")
+          |> Enum.map_join("|", &(&1 || ""))
 
         hash = :crypto.hash(:sha256, hash_input) |> Base.encode16(case: :lower)
         put_change(changeset, :utm_hash, hash)

--- a/lib/web/controllers/target_persona_controller.ex
+++ b/lib/web/controllers/target_persona_controller.ex
@@ -1,0 +1,74 @@
+defmodule Web.TargetPersonaController do
+  use Web, :controller
+  require Logger
+  import Plug.Conn
+  alias Core.Crm.TargetPersonas
+
+  def create(
+        conn,
+        %{
+          "tenant_id" => tenant_id,
+          "linkedin_url" => linkedin_url
+        } = _params
+      ) do
+    handle_create(conn, tenant_id, linkedin_url)
+  end
+
+  def create(conn, _params) do
+    conn
+    |> put_resp_content_type("application/json")
+    |> send_resp(
+      400,
+      Jason.encode!(%{
+        error: "Invalid request body. Required fields: tenant_id, linkedin_url"
+      })
+    )
+  end
+
+  defp handle_create(conn, tenant_id, linkedin_url) do
+    case TargetPersonas.create_from_linkedin(tenant_id, linkedin_url) do
+      {:ok, personas} when is_list(personas) ->
+        conn
+        |> put_resp_content_type("application/json")
+        |> send_resp(
+          201,
+          Jason.encode!(%{
+            message: "Target personas created successfully",
+            count: length(personas)
+          })
+        )
+
+      {:ok, _persona} ->
+        conn
+        |> put_resp_content_type("application/json")
+        |> send_resp(
+          201,
+          Jason.encode!(%{message: "Target persona created successfully"})
+        )
+
+      {:error, :tenant_not_found} ->
+        conn
+        |> put_resp_content_type("application/json")
+        |> send_resp(404, Jason.encode!(%{error: "Tenant not found"}))
+
+      {:error, :target_persona_creation_failed} ->
+        conn
+        |> put_resp_content_type("application/json")
+        |> send_resp(
+          422,
+          Jason.encode!(%{error: "Failed to create target persona"})
+        )
+
+      {:error, reason} ->
+        Logger.error("Target persona creation failed", %{
+          tenant_id: tenant_id,
+          linkedin_url: linkedin_url,
+          reason: reason
+        })
+
+        conn
+        |> put_resp_content_type("application/json")
+        |> send_resp(500, Jason.encode!(%{error: "Internal server error"}))
+    end
+  end
+end

--- a/lib/web/router.ex
+++ b/lib/web/router.ex
@@ -188,6 +188,8 @@ defmodule Web.Router do
 
     resources "/documents", DocumentController,
       only: [:create, :update, :delete]
+
+    post "/target-personas", TargetPersonaController, :create
   end
 
   # Flexible authentication (supports both session and Bearer token)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds API for creating target personas from LinkedIn URLs with tenant validation and refactors avatar processing and hash generation.
> 
>   - **New Feature**:
>     - Adds `create_from_linkedin/2` in `TargetPersonas` to create personas from LinkedIn URLs, with tenant validation.
>     - Introduces `TargetPersonaController` to handle persona creation requests.
>     - Adds POST `/target-personas` endpoint in `router.ex`.
>   - **Refactoring**:
>     - Refactors `process_avatar_for_contact` in `contacts.ex` to separate logic for contacts with and without avatars.
>     - Optimizes hash generation in `PaidCampaign` and `UtmCampaign` by using `Enum.map_join/3`.
>   - **Error Handling**:
>     - Adds error handling for tenant not found and persona creation failure in `TargetPersonaController`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for f16a40f0c9d468e65fa2f54d0d6eff76e752cff1. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->