### PR TITLE
patch: add disqualification reason to icp

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -91,8 +91,7 @@ config :core, :better_contact,
 config :core, :ai,
   anthropic_api_path: "https://api.anthropic.com/v1/messages",
   anthropic_api_key: get_env.("ANTHROPIC_API_KEY", nil),
-  gemini_api_path:
-    "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent",
+  gemini_api_path: "https://generativelanguage.googleapis.com/v1beta/models",
   gemini_api_key: get_env.("GEMINI_API_KEY", nil),
   groq_api_path: "https://api.groq.com/openai/v1/chat/completions",
   groq_api_key: get_env.("GROQ_API_KEY", nil)

--- a/lib/core/ai/anthropic/ask.ex
+++ b/lib/core/ai/anthropic/ask.ex
@@ -36,9 +36,6 @@ defmodule Core.Ai.Anthropic.Ask do
   @content_type_header "content-type"
   @default_api_version "2023-06-01"
 
-  @haiku_version "claude-3-5-haiku-20241022"
-  @sonnet_version "claude-3-5-sonnet-20241022"
-
   @spec ask(Request.t(), Config.t()) ::
           {:ok, String.t()} | {:error, any()}
   def ask(%Request{} = message, %Config{} = config) do
@@ -55,8 +52,8 @@ defmodule Core.Ai.Anthropic.Ask do
   defp build_request(%Request{} = message) do
     model_name =
       case message.model do
-        :claude_haiku -> @haiku_version
-        :claude_sonnet -> @sonnet_version
+        :claude_haiku_3_5 -> "claude-3-5-haiku-latest"
+        :claude_sonnet_4_0 -> "claude-sonnet-4-0"
       end
 
     request = %ApiRequest{

--- a/lib/core/ai/anthropic/request.ex
+++ b/lib/core/ai/anthropic/request.ex
@@ -4,7 +4,7 @@ defmodule Core.Ai.Anthropic.Request do
   Represents a request to ask a question to Claude.
   """
 
-  @type model :: :claude_haiku | :claude_sonnet
+  @type model :: :claude_haiku_3_5 | :claude_sonnet_4_0
 
   @type t :: %__MODULE__{
           model: model(),
@@ -27,8 +27,8 @@ defmodule Core.Ai.Anthropic.Request do
   """
   def validate(%__MODULE__{} = request) do
     cond do
-      request.model not in [:claude_haiku, :claude_sonnet] ->
-        {:error, "model must be :claude_haiku or :claude_sonnet"}
+      request.model not in [:claude_haiku_3_5, :claude_sonnet_4_0] ->
+        {:error, "invalid anthropic model"}
 
       is_nil(request.prompt) or request.prompt == "" ->
         {:error, "prompt cannot be empty"}

--- a/lib/core/ai/ask_ai.ex
+++ b/lib/core/ai/ask_ai.ex
@@ -30,9 +30,23 @@ defmodule Core.Ai do
   alias Core.Ai.Groq
   alias Core.Ai.Request
 
-  @anthropic_models [:claude_haiku, :claude_sonnet]
-  @gemini_models [:gemini_pro, :gemini_flash]
-  @groq_models [:llama3_70b, :llama3_8b, :llama33_70b, :llama31_8b, :gemma2_9b]
+  @anthropic_models [:claude_haiku_3_5, :claude_sonnet_4_0]
+  @gemini_models [
+    :gemma3_27b,
+    :gemini_flash_2_0,
+    :gemini_flash_2_5,
+    :gemini_flash_light_2_5,
+    :gemini_pro_2_5
+  ]
+  @groq_models [
+    :llama4_maverick,
+    :llama4_scout,
+    :llama3_70b,
+    :llama3_8b,
+    :llama33_70b,
+    :llama31_8b,
+    :qwen_qwq32b
+  ]
   @supported_models @anthropic_models ++ @gemini_models ++ @groq_models
 
   @doc """

--- a/lib/core/ai/gemini/ask.ex
+++ b/lib/core/ai/gemini/ask.ex
@@ -152,7 +152,6 @@ defmodule Core.Ai.Gemini.Ask do
     url =
       "#{url}/#{get_model_id(model)}:generateContent?#{@api_key_param}=#{config.api_key}"
 
-    dbg(url)
     headers = [{@content_type_header, "application/json"}]
     Finch.build(:post, url, headers, body)
   end

--- a/lib/core/ai/gemini/config.ex
+++ b/lib/core/ai/gemini/config.ex
@@ -27,7 +27,7 @@ defmodule Core.Ai.Gemini.Config do
     %__MODULE__{
       api_path:
         ai_config[:gemini_api_path] ||
-          "https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent",
+          "https://generativelanguage.googleapis.com/v1beta/models",
       api_key: ai_config[:gemini_api_key],
       timeout: ai_config[:timeout] || 45_000
     }

--- a/lib/core/ai/gemini/request.ex
+++ b/lib/core/ai/gemini/request.ex
@@ -2,7 +2,12 @@ defmodule Core.Ai.Gemini.Request do
   @moduledoc """
   Represents a request to ask a question to Gemini.
   """
-  @type model :: :gemini_pro | :gemini_flash
+  @type model ::
+          :gemma3_27b
+          | :gemini_flash_2_0
+          | :gemini_flash_2_5
+          | :gemini_flash_light_2_5
+          | :gemini_pro_2_5
   @type response_type :: :text | :json
 
   @type t :: %__MODULE__{
@@ -11,7 +16,7 @@ defmodule Core.Ai.Gemini.Request do
           system_prompt: String.t() | nil,
           max_output_tokens: integer() | nil,
           model_temperature: float() | nil,
-          response_type: response_type()
+          response_type: response_type
         }
 
   defstruct [
@@ -25,7 +30,13 @@ defmodule Core.Ai.Gemini.Request do
 
   def validate(%__MODULE__{} = request) do
     cond do
-      request.model not in [:gemini_pro, :gemini_flash] ->
+      request.model not in [
+        :gemma3_27b,
+        :gemini_flash_2_0,
+        :gemini_flash_2_5,
+        :gemini_flash_light_2_5,
+        :gemini_pro_2_5
+      ] ->
         {:error, "model must be :gemini_pro or :gemini_flash"}
 
       is_nil(request.prompt) or request.prompt == "" ->

--- a/lib/core/ai/groq/ask.ex
+++ b/lib/core/ai/groq/ask.ex
@@ -39,6 +39,9 @@ defmodule Core.Ai.Groq.Ask do
   @llama33_70b_model "llama-3.3-70b-versatile"
   @llama31_8b_model "llama-3.1-8b-instant"
   @gemma2_9b_model "gemma2-9b-it"
+  @llama4_scout_model "meta-llama/llama-4-scout-17b-16e-instruct"
+  @llama4_maverick_model "meta-llama/llama-4-maverick-17b-128e-instruct"
+  @qwen_qwq32b "qwen-qwq-32b"
 
   @spec ask(Request.t(), Config.t()) ::
           {:ok, String.t()} | {:error, any()}
@@ -61,6 +64,9 @@ defmodule Core.Ai.Groq.Ask do
         :llama33_70b -> @llama33_70b_model
         :llama31_8b -> @llama31_8b_model
         :gemma2_9b -> @gemma2_9b_model
+        :llama4_scout -> @llama4_scout_model
+        :llama4_maverick -> @llama4_maverick_model
+        :qwen_qwq32b -> @qwen_qwq32b
       end
 
     messages =

--- a/lib/core/ai/groq/request.ex
+++ b/lib/core/ai/groq/request.ex
@@ -1,12 +1,18 @@
 defmodule Core.Ai.Groq.Request do
-  @derive Jason.Encoder
   @moduledoc """
   Represents a request to ask a question to Groq AI.
   """
-
+  
   @type model ::
-          :llama3_70b | :llama3_8b | :llama33_70b | :llama31_8b | :gemma2_9b
-
+          :llama3_70b
+          | :llama3_8b
+          | :llama33_70b
+          | :llama31_8b
+          | :gemma2_9b
+          | :llama4_scout
+          | :llama4_maverick
+          | :qwen_qwq32b
+          
   @type t :: %__MODULE__{
           model: model(),
           prompt: String.t(),
@@ -14,7 +20,7 @@ defmodule Core.Ai.Groq.Request do
           max_output_tokens: integer() | nil,
           model_temperature: float() | nil
         }
-
+        
   defstruct [
     :model,
     :prompt,
@@ -22,6 +28,14 @@ defmodule Core.Ai.Groq.Request do
     max_output_tokens: 1024,
     model_temperature: 0.7
   ]
+
+  defimpl Jason.Encoder do
+    def encode(request, opts) do
+      request
+      |> Map.from_struct()
+      |> Jason.Encode.map(opts)
+    end
+  end
 
   @doc """
   Validates the request and returns errors if any.
@@ -33,14 +47,14 @@ defmodule Core.Ai.Groq.Request do
         :llama3_8b,
         :llama33_70b,
         :llama31_8b,
-        :gemma2_9b
+        :gemma2_9b,
+        :llama4_scout,
+        :llama4_maverick,
+        :qwen_qwq32b
       ] ->
-        {:error,
-         "model must be one of: :llama3_70b, :llama3_8b, :llama33_70b, :llama31_8b, or :gemma2_9b"}
-
+        {:error, "invalid groq model"}
       is_nil(request.prompt) or request.prompt == "" ->
         {:error, "prompt cannot be empty"}
-
       true ->
         :ok
     end

--- a/lib/core/ai/request.ex
+++ b/lib/core/ai/request.ex
@@ -2,15 +2,30 @@ defmodule Core.Ai.Request do
   @moduledoc """
   Represents a request to ask a question to an AI Model.
   """
-  @default_model :claude_haiku
+  @default_model :claude_haiku_3_5
   @default_max_tokens 512
   @default_temperature 0.2
   @default_response_type :text
 
-  @type model :: :claude_haiku | :claude_sonnet | :gemini_pro | :gemini_flash
+  @type model ::
+          :claude_haiku_3_5
+          | :claude_sonnet_4_0
+          | :llama3_70b
+          | :llama3_8b
+          | :llama33_70b
+          | :llama31_8b
+          | :llama4_scout
+          | :llama4_maverick
+          | :qwen_qwq32b
+          | :gemma3_27b
+          | :gemini_flash_2_0
+          | :gemini_flash_2_5
+          | :gemini_flash_light_2_5
+          | :gemini_pro_2_5
+
   @type response_type :: :text | :json
   @type t :: %__MODULE__{
-          model: model(),
+          model: model,
           prompt: String.t(),
           system_prompt: String.t() | nil,
           max_output_tokens: integer() | nil,

--- a/lib/core/crm/leads/lead.ex
+++ b/lib/core/crm/leads/lead.ex
@@ -23,6 +23,23 @@ defmodule Core.Crm.Leads.Lead do
           | :ready_to_buy
           | :customer
   @type icp_fit :: :strong | :moderate | :not_a_fit
+  @type disqualification_reason ::
+          :company_too_small
+          | :company_too_large
+          | :company_declining
+          | :competitor
+          | :incompatible_tech_stack
+          | :legacy_system_constraints
+          | :market_position_mismatch
+          | :no_use_case
+          | :regulatory_restrictions
+          | :revenue_model_mismatch
+          | :startup_too_early
+          | :unable_to_determine_fit
+          | :wrong_industry
+          | :wrong_geography
+          | :wrong_business_model
+
   @type t :: %__MODULE__{
           id: String.t(),
           tenant_id: String.t(),
@@ -30,6 +47,7 @@ defmodule Core.Crm.Leads.Lead do
           type: lead_type,
           stage: lead_stage,
           icp_fit: icp_fit,
+          icp_disqualification_reason: [disqualification_reason],
           error_message: String.t(),
           icp_fit_evaluation_attempt_at: DateTime.t(),
           icp_fit_evaluation_attempts: integer(),
@@ -60,6 +78,26 @@ defmodule Core.Crm.Leads.Lead do
       default: :pending
     )
 
+    field(:icp_disqualification_reason, {:array, Ecto.Enum},
+      values: [
+        :company_too_small,
+        :company_too_large,
+        :company_declining,
+        :competitor,
+        :incompatible_tech_stack,
+        :legacy_system_constraints,
+        :market_position_mismatch,
+        :no_use_case,
+        :regulatory_restrictions,
+        :revenue_model_mismatch,
+        :startup_too_early,
+        :unable_to_determine_fit,
+        :wrong_industry,
+        :wrong_geography,
+        :wrong_business_model
+      ]
+    )
+
     field(:error_message, :string)
     field(:icp_fit_evaluation_attempt_at, :utc_datetime)
     field(:icp_fit_evaluation_attempts, :integer, default: 0)
@@ -86,7 +124,8 @@ defmodule Core.Crm.Leads.Lead do
     :icp_fit_evaluation_attempts,
     :brief_create_attempt_at,
     :brief_create_attempts,
-    :just_created
+    :just_created,
+    :icp_disqualification_reason
   ]
 
   def changeset(%__MODULE__{} = lead, attrs) do

--- a/lib/core/researcher/crawler.ex
+++ b/lib/core/researcher/crawler.ex
@@ -8,7 +8,7 @@ defmodule Core.Researcher.Crawler do
 
   @default_opts [
     max_depth: 2,
-    max_pages: 100,
+    max_pages: 30,
     delay: 100,
     concurrency: 5
   ]

--- a/lib/core/researcher/icp_fit_evaluator/prompt_builder.ex
+++ b/lib/core/researcher/icp_fit_evaluator/prompt_builder.ex
@@ -9,7 +9,7 @@ defmodule Core.Researcher.IcpFitEvaluator.PromptBuilder do
 
   alias Core.Researcher.Scraper
   alias Core.Ai
-  @model :claude_sonnet
+  @model :gemini_flash_2_0
   @model_temperature 0.2
   @max_tokens 156
 
@@ -18,7 +18,8 @@ defmodule Core.Researcher.IcpFitEvaluator.PromptBuilder do
       model: @model,
       system_prompt: system_prompt,
       max_tokens: @max_tokens,
-      temperature: @model_temperature
+      temperature: @model_temperature,
+      response_type: :json
     )
   end
 
@@ -42,12 +43,85 @@ defmodule Core.Researcher.IcpFitEvaluator.PromptBuilder do
       end
 
     system_prompt = """
-      I will provide you with a B2B company and relevant context from their website.  I will also provide you with a description of my business, my ideal customer profile and qualifying criteria.  Your job is to determine how well the company matches my ideal customer profile.  Valid response values are "strong", "moderate", "not a fit".  Please only return one of these three values.
-      NOTE: If the company I provide you sells a product or service that is a substitute for my product or service, they are a competitor.  Return "not a fit".
-      IMPORTANT:  Your response MUST be in valid JSON format exactly matching this schema:
-      {
-        "icp_fit": "strong"
-      }
+    I will provide you with a B2B company and relevant context from their website. I will also provide you with a description of my business, my ideal customer profile and qualifying criteria. Your job is to determine how well the company matches my ideal customer profile.
+
+    Valid response values are "strong", "moderate", "not_a_fit". 
+
+    IMPORTANT: Err on the side of qualifying companies. Only mark as "not_a_fit" if there are CLEAR disqualifiers that make the company unsuitable. 
+
+      Guidelines for qualification:
+    - "strong" -> Company shows good potential and matches key criteria. Look for positive indicators rather than requiring perfect alignment. Consider companies "strong" if they:
+    * Match the target industry OR adjacent/related industries that could benefit
+    * Are in the right size range OR show growth trajectory toward the ideal size
+    * Have business models that could reasonably use our solution
+    * Show signs of growth, funding, hiring, or expansion
+    * Have pain points our solution addresses (even if not explicitly stated)
+    * Operate in our target geography OR have presence/expansion there
+    * Are in market segments that historically convert well
+
+    - "moderate" -> Company has some potential but unclear fit, mixed signals, or limited information
+
+    - "not_a_fit" -> Company has clear, fundamental incompatibilities that make them completely unsuitable
+
+    QUALIFICATION MINDSET: 
+    - Focus on what COULD work rather than what might not work
+    - Give companies the benefit of the doubt when information is unclear
+    - Consider growth potential and future needs, not just current state
+    - Look for indirect indicators of fit (hiring patterns, funding, partnerships, technology mentions)
+    - Remember that companies often don't explicitly state all their pain points on their website
+    - Adjacent industries and use cases can still be strong fits
+    - If a company seems professional, growing, and in a reasonable industry/size range, lean toward "strong"
+
+    Only return "not_a_fit" if one or more of these MAJOR disqualifiers apply:
+    - competitor -> company sells a product or service that directly competes with my product or service
+    - wrong_industry -> company operates in an industry that is fundamentally incompatible with our products/services
+    - company_too_small -> company is clearly too small for us to service (well below minimum thresholds)
+    - company_too_large -> company is clearly too big for us to service effectively (well above maximum thresholds)
+    - no_use_case -> there is absolutely no conceivable path to ROI for adopting our product/service
+    - wrong_geography -> company operates in a geographic location we cannot serve
+    - regulatory_restrictions -> there are insurmountable legal/compliance barriers
+    - unable_to_determine_fit -> insufficient information to make any determination
+
+    For edge cases or minor concerns, choose "moderate" instead of "not_a_fit".
+
+    COMPETITOR DEFINITION:
+    A company is only considered a "competitor" if they offer a product or service that DIRECTLY substitutes for or replaces our core offering. Be specific and conservative with this designation:
+
+    CLEAR COMPETITORS (mark as "not_a_fit"):
+    - Companies that sell the exact same product/service we do
+    - Direct substitutes that solve the same core problem in the same way
+    - Companies explicitly positioned as alternatives to solutions like ours
+    - Vendors whose primary business model directly conflicts with ours
+
+    NOT COMPETITORS (can still be "strong" or "moderate"):
+    - Companies that offer complementary products/services (could be integration partners)
+    - Vendors in adjacent markets that don't directly compete for the same budget/decision
+    - Companies with overlapping features but different primary use cases
+    - Platform/ecosystem players where we could potentially integrate
+    - Companies targeting different market segments (SMB vs Enterprise) even with similar products
+    - Services companies that might resell or implement our solution
+    - Companies with some competitive features but primarily different value propositions
+    - Potential partners, resellers, or integration opportunities
+
+      Examples:
+    - If we sell CRM software, Salesforce = competitor, but marketing automation tools = not competitor
+    - If we sell accounting software, QuickBooks = competitor, but tax preparation services = not competitor
+    - If we sell HR software, Workday = competitor, but recruiting agencies = not competitor
+
+    IMPORTANT: Your response MUST be in valid JSON format exactly matching this schema:
+    {
+      "icp_fit": "strong"
+    }
+    or
+    {
+      "icp_fit": "moderate"
+    }
+    or if "not_a_fit"
+    {
+      "icp_fit": "not_a_fit",
+      "reasons": ["competitor", "wrong_industry"]
+    }
+
     Do not include any text outside the JSON object.
     """
 

--- a/lib/core/researcher/icp_fit_evaluator/validator.ex
+++ b/lib/core/researcher/icp_fit_evaluator/validator.ex
@@ -1,30 +1,64 @@
 defmodule Core.Researcher.IcpFitEvaluator.Validator do
   @moduledoc """
   Validates and parses ICP fit evaluation responses.
-
   This module handles:
   * Validation of ICP fit responses
   * Parsing of fit values into atoms
+  * Validation of disqualification reasons for "not a fit" responses
   * JSON response validation
   * Error handling for invalid responses
-
   It ensures that ICP fit evaluations follow a strict format
   and can only return valid fit values (:strong, :moderate,
-  or :not_a_fit). The module provides clear error messages
-  for any validation failures.
+  or :not_a_fit) with appropriate disqualification reasons when applicable.
   """
 
-  @valid_fits ["strong", "moderate", "not a fit"]
+  @valid_fits ["strong", "moderate", "not_a_fit"]
   @fit_atoms %{
     "strong" => :strong,
     "moderate" => :moderate,
-    "not a fit" => :not_a_fit
+    "not_a_fit" => :not_a_fit
+  }
+
+  @valid_disqualification_reasons [
+    "company_too_small",
+    "company_too_large",
+    "startup_too_early",
+    "wrong_industry",
+    "regulated_industry_mismatch",
+    "wrong_geography",
+    "regulatory_restrictions",
+    "wrong_business_model",
+    "revenue_model_mismatch",
+    "market_position_mismatch",
+    "incompatible_tech_stack",
+    "legacy_system_constraints",
+    "no_use_case",
+    "competitor",
+    "unable_to_determine_fit"
+  ]
+
+  @reason_atoms %{
+    "company_too_small" => :company_too_small,
+    "company_too_large" => :company_too_large,
+    "startup_too_early" => :startup_too_early,
+    "wrong_industry" => :wrong_industry,
+    "regulated_industry_mismatch" => :regulated_industry_mismatch,
+    "wrong_geography" => :wrong_geography,
+    "regulatory_restrictions" => :regulatory_restrictions,
+    "wrong_business_model" => :wrong_business_model,
+    "revenue_model_mismatch" => :revenue_model_mismatch,
+    "market_position_mismatch" => :market_position_mismatch,
+    "incompatible_tech_stack" => :incompatible_tech_stack,
+    "legacy_system_constraints" => :legacy_system_constraints,
+    "no_use_case" => :no_use_case,
+    "competitor" => :competitor,
+    "unable_to_determine_fit" => :unable_to_determine_fit
   }
 
   def validate_and_parse(response) when is_binary(response) do
     with {:ok, parsed} <- Jason.decode(response),
-         {:ok, fit} <- extract_icp_fit(parsed) do
-      {:ok, fit}
+         {:ok, result} <- extract_icp_evaluation(parsed) do
+      {:ok, result}
     else
       {:error, %Jason.DecodeError{}} ->
         {:error, "Invalid JSON format in AI response"}
@@ -36,30 +70,81 @@ defmodule Core.Researcher.IcpFitEvaluator.Validator do
 
   def validate_and_parse(_), do: {:error, "Response must be a string"}
 
-  # Handle the expected simple schema from your system prompt
-  defp extract_icp_fit(%{"icp_fit" => fit}) when is_binary(fit) do
-    trimmed_fit = String.trim(fit)
-
-    if trimmed_fit in @valid_fits do
-      {:ok, Map.get(@fit_atoms, trimmed_fit)}
-    else
-      {:error,
-       "Invalid icp_fit value: '#{trimmed_fit}'. Must be one of: #{Enum.join(@valid_fits, ", ")}"}
+  # Handle "not a fit" responses with reasons
+  defp extract_icp_evaluation(%{"icp_fit" => "not_a_fit", "reasons" => reasons})
+       when is_list(reasons) do
+    with {:ok, validated_reasons} <- validate_reasons(reasons) do
+      {:ok,
+       %{icp_fit: :not_a_fit, icp_disqualification_reason: validated_reasons}}
     end
   end
 
+  # Handle "not a fit" responses missing reasons
+  defp extract_icp_evaluation(%{"icp_fit" => "not_a_fit"}) do
+    {:error, "Missing required 'reasons' field for 'not_a_fit' response"}
+  end
+
+  # Handle "strong" and "moderate" responses (no reasons expected)
+  defp extract_icp_evaluation(%{"icp_fit" => fit})
+       when fit in ["strong", "moderate"] do
+    {:ok, %{icp_fit: Map.get(@fit_atoms, fit), icp_disqualification_reason: []}}
+  end
+
+  # Handle invalid icp_fit values
+  defp extract_icp_evaluation(%{"icp_fit" => fit}) when is_binary(fit) do
+    trimmed_fit = String.trim(fit)
+
+    {:error,
+     "Invalid icp_fit value: '#{trimmed_fit}'. Must be one of: #{Enum.join(@valid_fits, ", ")}"}
+  end
+
   # Handle case where icp_fit is missing
-  defp extract_icp_fit(%{} = parsed) when not is_map_key(parsed, "icp_fit") do
+  defp extract_icp_evaluation(%{} = parsed)
+       when not is_map_key(parsed, "icp_fit") do
     {:error, "Missing required field: icp_fit"}
   end
 
   # Handle case where icp_fit is not a string
-  defp extract_icp_fit(%{"icp_fit" => fit}) when not is_binary(fit) do
+  defp extract_icp_evaluation(%{"icp_fit" => fit}) when not is_binary(fit) do
     {:error, "icp_fit must be a string, got: #{inspect(fit)}"}
   end
 
   # Handle completely unexpected structure
-  defp extract_icp_fit(parsed) do
+  defp extract_icp_evaluation(parsed) do
     {:error, "Unexpected JSON structure: #{inspect(parsed)}"}
+  end
+
+  defp validate_reasons(reasons) when is_list(reasons) do
+    if Enum.empty?(reasons) do
+      {:error, "Reasons list cannot be empty for 'not_a_fit' response"}
+    else
+      case validate_reason_list(reasons, []) do
+        {:ok, validated} -> {:ok, Enum.reverse(validated)}
+        {:error, reason} -> {:error, reason}
+      end
+    end
+  end
+
+  defp validate_reasons(_) do
+    {:error, "Reasons must be a list"}
+  end
+
+  defp validate_reason_list([], acc), do: {:ok, acc}
+
+  defp validate_reason_list([reason | rest], acc) when is_binary(reason) do
+    trimmed_reason = String.trim(reason)
+
+    if trimmed_reason in @valid_disqualification_reasons do
+      atom_reason = Map.get(@reason_atoms, trimmed_reason)
+      validate_reason_list(rest, [atom_reason | acc])
+    else
+      {:error,
+       "Invalid disqualification reason: '#{trimmed_reason}'. Must be one of: #{Enum.join(@valid_disqualification_reasons, ", ")}"}
+    end
+  end
+
+  defp validate_reason_list([reason | _], _) do
+    {:error,
+     "Disqualification reason must be a string, got: #{inspect(reason)}"}
   end
 end

--- a/lib/core/web_tracker/channel_classifier.ex
+++ b/lib/core/web_tracker/channel_classifier.ex
@@ -23,13 +23,11 @@ defmodule Core.WebTracker.ChannelClassifier do
       referrer_domain in tenant_domains
     else
       {:error, reason} ->
-        Logger.error(
-          "failed to determine if referrer is internal: #{inspect(reason)}",
-          %{
-            tenant_domains: tenant_domains,
-            referrer: referrer
-          }
-        )
+        Logger.error("failed to determine if referrer is internal", %{
+          tenant_domains: tenant_domains,
+          referrer: referrer,
+          reason: reason
+        })
 
         false
     end

--- a/priv/repo/migrations/20250703113059_add_disqualification_reason_to_leads.exs
+++ b/priv/repo/migrations/20250703113059_add_disqualification_reason_to_leads.exs
@@ -1,0 +1,9 @@
+defmodule Core.Repo.Migrations.AddDisqualificationReasonToLeads do
+  use Ecto.Migration
+
+  def change do
+    alter table(:leads) do
+      add :icp_disqualification_reason, {:array, :string}, default: []
+    end
+  end
+end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add disqualification reasons to lead evaluation in CRM, update AI models, and modify database schema.
> 
>   - **Behavior**:
>     - Adds `icp_disqualification_reason` field to `Lead` model in `lead.ex` to store reasons for disqualification.
>     - Updates `evaluate_icp_fit()` in `icp_fit_evaluator.ex` to handle disqualification reasons.
>     - Modifies `validate_and_parse()` in `validator.ex` to parse disqualification reasons from AI responses.
>   - **Models**:
>     - Updates `Lead` schema in `lead.ex` to include `icp_disqualification_reason` as an array of enums.
>     - Adds migration `20250703113059_add_disqualification_reason_to_leads.exs` to add `icp_disqualification_reason` column to `leads` table.
>   - **AI Integration**:
>     - Updates AI request models in `request.ex` to support new models and response types.
>     - Modifies `ask()` functions in `ask_ai.ex`, `anthropic/ask.ex`, `gemini/ask.ex`, and `groq/ask.ex` to handle new model names and configurations.
>   - **Misc**:
>     - Changes `max_pages` in `crawler.ex` from 100 to 30.
>     - Updates logging in `channel_classifier.ex` to include error reasons.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for 9979202bb6f316912fb64b3d0405c6c0e555f158. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->