### PR TITLE
patch: retry target persona creation

### DIFF
--- a/lib/application.ex
+++ b/lib/application.ex
@@ -28,6 +28,7 @@ defmodule Core.Application do
       Core.Crm.Companies.CompanyScrapinEnricher,
       Core.Crm.Companies.CompanyDomainProcessor,
       Core.Crm.Leads.LeadCreator,
+      Core.Crm.TargetPersonas.TargetPersonaLinkedinProcessor,
       Core.Crm.Leads.IcpFitEvaluator,
       Core.Crm.Leads.DailyLeadSummarySender,
       Core.Crm.Leads.BriefCreator,

--- a/lib/core/crm/target_personas/target_persona_linkedin_processor.ex
+++ b/lib/core/crm/target_personas/target_persona_linkedin_processor.ex
@@ -1,0 +1,206 @@
+defmodule Core.Crm.TargetPersonas.TargetPersonaLinkedinProcessor do
+  @moduledoc """
+  Job responsible for processing target persona LinkedIn queue records.
+  """
+
+  use GenServer
+  require Logger
+  require OpenTelemetry.Tracer
+  alias Core.Crm.TargetPersonas
+  alias Core.Crm.TargetPersonas.TargetPersonaLinkedinQueue
+  alias Core.Crm.TargetPersonas.TargetPersonaLinkedinQueues
+  alias Core.Repo
+  alias Core.Utils.Tracing
+  alias Core.Utils.CronLocks
+  alias Core.Utils.Cron.CronLock
+
+  @default_interval 2 * 60 * 1000
+  @batch_size 10
+  @stuck_lock_duration_minutes 30
+  @max_retries 5
+  @retry_delay_hours 24
+
+  @doc """
+  Starts the target persona LinkedIn processor process.
+  """
+  def start_link(_opts) do
+    # crons_enabled = Application.get_env(:core, :crons)[:enabled] || false
+    crons_enabled = true
+
+    if crons_enabled do
+      GenServer.start_link(__MODULE__, %{}, name: __MODULE__)
+    else
+      Logger.info(
+        "Target persona LinkedIn processor is disabled (crons disabled)"
+      )
+
+      :ignore
+    end
+  end
+
+  # Server Callbacks
+
+  @impl true
+  def init(_) do
+    CronLocks.register_cron(:cron_target_persona_linkedin_processor)
+    schedule_initial_check()
+    {:ok, %{}}
+  end
+
+  @impl true
+  def handle_info(:check_target_persona_linkedin_queues, state) do
+    OpenTelemetry.Tracer.with_span "target_persona_linkedin_processor.check_queues" do
+      lock_uuid = Ecto.UUID.generate()
+
+      case CronLocks.acquire_lock(
+             :cron_target_persona_linkedin_processor,
+             lock_uuid
+           ) do
+        %CronLock{} ->
+          case fetch_target_persona_linkedin_queues_to_process() do
+            {:ok, queue_records} ->
+              OpenTelemetry.Tracer.set_attributes([
+                {"queue_records.count", length(queue_records)}
+              ])
+
+              process_queue_records(queue_records)
+
+            {:error, :not_found} ->
+              OpenTelemetry.Tracer.set_attributes([
+                {"queue_records.count", 0}
+              ])
+
+              Logger.debug(
+                "No target persona LinkedIn queue records found for processing"
+              )
+          end
+
+          CronLocks.release_lock(
+            :cron_target_persona_linkedin_processor,
+            lock_uuid
+          )
+
+        nil ->
+          Logger.info(
+            "Target persona LinkedIn processor lock not acquired, attempting to release any stuck locks"
+          )
+
+          case CronLocks.force_release_stuck_lock(
+                 :cron_target_persona_linkedin_processor,
+                 @stuck_lock_duration_minutes
+               ) do
+            :ok ->
+              Logger.info(
+                "Successfully released stuck lock, will retry acquisition on next run"
+              )
+
+            :error ->
+              Logger.info("No stuck lock found or could not release it")
+          end
+      end
+
+      schedule_next_check()
+      {:noreply, state}
+    end
+  end
+
+  # Private Functions
+
+  defp process_queue_record(%TargetPersonaLinkedinQueue{} = queue_record) do
+    OpenTelemetry.Tracer.with_span "target_persona_linkedin_processor.process_record" do
+      OpenTelemetry.Tracer.set_attributes([
+        {"param.linkedin_url", queue_record.linkedin_url},
+        {"param.tenant_id", queue_record.tenant_id},
+        {"param.attempts", queue_record.attempts}
+      ])
+
+      case TargetPersonaLinkedinQueues.update_attempt(queue_record.id) do
+        {:ok, _updated_record} ->
+          result =
+            TargetPersonas.create_from_linkedin(
+              queue_record.tenant_id,
+              queue_record.linkedin_url
+            )
+
+          case result do
+            {:ok, _personas} ->
+              case TargetPersonaLinkedinQueues.mark_completed(queue_record.id) do
+                {:ok, _completed_record} ->
+                  {:ok, :completed}
+
+                {:error, reason} ->
+                  Tracing.error(reason, "Failed to mark record as completed",
+                    id: queue_record.id
+                  )
+
+                  {:error, :mark_completed_failed}
+              end
+
+            {:error, reason} ->
+              Tracing.error(
+                reason,
+                "Failed to process target persona LinkedIn record",
+                id: queue_record.id,
+                linkedin_url: queue_record.linkedin_url
+              )
+
+              {:error, :reason}
+          end
+
+        {:error, reason} ->
+          Logger.error("Failed to update attempt for queue record",
+            id: queue_record.id,
+            reason: reason
+          )
+
+          {:error, :update_attempt_failed}
+      end
+    end
+  end
+
+  defp process_queue_records(queue_records) do
+    Enum.each(queue_records, &process_queue_record/1)
+  end
+
+  defp schedule_initial_check do
+    Process.send_after(
+      self(),
+      :check_target_persona_linkedin_queues,
+      @default_interval
+    )
+  end
+
+  defp schedule_next_check do
+    Process.send_after(
+      self(),
+      :check_target_persona_linkedin_queues,
+      @default_interval
+    )
+  end
+
+  defp fetch_target_persona_linkedin_queues_to_process() do
+    retry_delay_threshold =
+      DateTime.utc_now()
+      |> DateTime.add(-@retry_delay_hours * 60 * 60, :second)
+
+    import Ecto.Query
+
+    TargetPersonaLinkedinQueue
+    |> where([q], is_nil(q.completed_at))
+    |> where([q], q.attempts < ^@max_retries)
+    |> where(
+      [q],
+      is_nil(q.last_attempt_at) or q.last_attempt_at < ^retry_delay_threshold
+    )
+    |> order_by([q], asc_nulls_first: q.last_attempt_at)
+    |> limit(^@batch_size)
+    |> Repo.all()
+    |> case do
+      [] ->
+        {:error, :not_found}
+
+      records ->
+        {:ok, records}
+    end
+  end
+end

--- a/lib/core/crm/target_personas/target_persona_linkedin_queue.ex
+++ b/lib/core/crm/target_personas/target_persona_linkedin_queue.ex
@@ -1,0 +1,42 @@
+defmodule Core.Crm.TargetPersonas.TargetPersonaLinkedinQueue do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "target_persona_linkedin_queues" do
+    field(:tenant_id, :string)
+    field(:linkedin_url, :string)
+    field(:completed_at, :utc_datetime)
+    field(:last_attempt_at, :utc_datetime)
+    field(:attempts, :integer, default: 0)
+    field(:inserted_at, :utc_datetime)
+  end
+
+  @type t :: %__MODULE__{
+          id: String.t(),
+          tenant_id: String.t(),
+          linkedin_url: String.t(),
+          completed_at: DateTime.t(),
+          last_attempt_at: DateTime.t(),
+          attempts: integer(),
+          inserted_at: DateTime.t()
+        }
+
+  @required_fields [
+    :tenant_id,
+    :linkedin_url
+  ]
+
+  @doc false
+  def changeset(target_persona_linkedin_queue, attrs) do
+    target_persona_linkedin_queue
+    |> cast(attrs, [
+      :tenant_id,
+      :linkedin_url,
+      :completed_at,
+      :last_attempt_at,
+      :attempts
+    ])
+    |> validate_required(@required_fields)
+    |> validate_number(:attempts, greater_than_or_equal_to: 0)
+  end
+end

--- a/lib/core/crm/target_personas/target_persona_linkedin_queues.ex
+++ b/lib/core/crm/target_personas/target_persona_linkedin_queues.ex
@@ -1,0 +1,60 @@
+defmodule Core.Crm.TargetPersonas.TargetPersonaLinkedinQueues do
+  alias Core.Crm.TargetPersonas.TargetPersonaLinkedinQueue
+  alias Core.Repo
+  import Ecto.Query
+
+  def add_record(tenant_id, linkedin_url)
+      when is_binary(tenant_id) and is_binary(linkedin_url) do
+    case get_record_by_tenant_and_linkedin(tenant_id, linkedin_url) do
+      nil ->
+        %TargetPersonaLinkedinQueue{}
+        |> TargetPersonaLinkedinQueue.changeset(%{
+          tenant_id: tenant_id,
+          linkedin_url: linkedin_url
+        })
+        |> Repo.insert()
+
+      _existing_record ->
+        {:ok, nil}
+    end
+  end
+
+  def get_record_by_tenant_and_linkedin(tenant_id, linkedin_url) do
+    TargetPersonaLinkedinQueue
+    |> where([q], q.tenant_id == ^tenant_id and q.linkedin_url == ^linkedin_url)
+    |> Repo.one()
+  end
+
+  def update_attempt(record_id) do
+    TargetPersonaLinkedinQueue
+    |> Repo.get(record_id)
+    |> case do
+      nil ->
+        {:error, :not_found}
+
+      record ->
+        record
+        |> TargetPersonaLinkedinQueue.changeset(%{
+          attempts: record.attempts + 1,
+          last_attempt_at: DateTime.utc_now()
+        })
+        |> Repo.update()
+    end
+  end
+
+  def mark_completed(record_id) do
+    TargetPersonaLinkedinQueue
+    |> Repo.get(record_id)
+    |> case do
+      nil ->
+        {:error, :not_found}
+
+      record ->
+        record
+        |> TargetPersonaLinkedinQueue.changeset(%{
+          completed_at: DateTime.utc_now()
+        })
+        |> Repo.update()
+    end
+  end
+end

--- a/lib/core/scrapin/company/scrapin_companies.ex
+++ b/lib/core/scrapin/company/scrapin_companies.ex
@@ -142,8 +142,8 @@ defmodule Core.ScrapinCompanies do
               {:error, :not_found}
           end
         else
-          _error ->
-            {:error, :not_found}
+          {:error, reason} ->
+            {:error, reason}
         end
     end
   end

--- a/lib/core/scrapin/contact/scrapin_contacts.ex
+++ b/lib/core/scrapin/contact/scrapin_contacts.ex
@@ -186,8 +186,8 @@ defmodule Core.ScrapinContacts do
               {:error, :not_found}
           end
         else
-          _error ->
-            {:error, :not_found}
+          {:error, reason} ->
+            {:error, reason}
         end
     end
   end

--- a/lib/core/utils/cron/cron_lock.ex
+++ b/lib/core/utils/cron/cron_lock.ex
@@ -21,7 +21,8 @@ defmodule Core.Utils.Cron.CronLock do
     :cron_hubspot_company_sync,
     :cron_brief_creator,
     :cron_magic_link_usage_checker,
-    :cron_lead_creator
+    :cron_lead_creator,
+    :cron_target_persona_linkedin_processor
   ]
 
   @type cron_name :: unquote(Enum.reduce(@cron_names, &{:|, [], [&1, &2]}))

--- a/priv/repo/migrations/20250704135225_create_table_target_persona_linkedin_queues.exs
+++ b/priv/repo/migrations/20250704135225_create_table_target_persona_linkedin_queues.exs
@@ -1,0 +1,22 @@
+defmodule Core.Repo.Migrations.CreateTableContactLinkedinQueues do
+  use Ecto.Migration
+
+  def up do
+    create table(:target_persona_linkedin_queues) do
+      add :tenant_id, :string, null: false
+      add :linkedin_url, :string, null: false
+      add :inserted_at, :utc_datetime, null: false, default: fragment("CURRENT_TIMESTAMP")
+      add :completed_at, :utc_datetime, null: true
+      add :last_attempt_at, :utc_datetime, null: true
+      add :attempts, :integer, null: false, default: 0
+    end
+
+    create unique_index(:target_persona_linkedin_queues, [:tenant_id, :linkedin_url],
+             name: :target_persona_linkedin_queues_tenant_linkedin_url_unique_index
+           )
+  end
+
+  def down do
+    drop table(:target_persona_linkedin_queues)
+  end
+end

--- a/priv/repo/migrations/20250704144446_update_column_length_for_contacts.exs
+++ b/priv/repo/migrations/20250704144446_update_column_length_for_contacts.exs
@@ -1,0 +1,19 @@
+defmodule Core.Repo.Migrations.UpdateColumnLengthForContacts do
+  use Ecto.Migration
+
+  def up do
+    alter table(:contacts) do
+      modify :summary, :text
+      modify :headline, :text
+      modify :job_description, :text
+    end
+  end
+
+  def down do
+    alter table(:contacts) do
+      modify :summary, :string
+      modify :headline, :string
+      modify :job_description, :string
+    end
+  end
+end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds retry mechanism for LinkedIn target persona creation with a new GenServer and database schema changes.
> 
>   - **Behavior**:
>     - Adds `TargetPersonaLinkedinProcessor` GenServer in `application.ex` to process LinkedIn queue records.
>     - Updates `create_from_linkedin_id` and `create_from_linkedin_alias` in `target_personas.ex` to return personas and add failed records to queue.
>     - Adds retry logic in `target_persona_linkedin_processor.ex` with a max of 5 retries and a 24-hour delay.
>   - **Models**:
>     - Adds `TargetPersonaLinkedinQueue` schema in `target_persona_linkedin_queue.ex` for queue records.
>     - Adds `add_record`, `update_attempt`, and `mark_completed` functions in `target_persona_linkedin_queues.ex` for queue management.
>   - **Migrations**:
>     - Creates `target_persona_linkedin_queues` table in `20250704135225_create_table_target_persona_linkedin_queues.exs`.
>     - Updates `contacts` table column types to `text` in `20250704144446_update_column_length_for_contacts.exs`.
>   - **Misc**:
>     - Adds `cron_target_persona_linkedin_processor` to cron lock names in `cron_lock.ex`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for 1f00962df999f2ea768e903a64bb8ca3c7cbbee9. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->