### PR TITLE
patch: replace error with warning

### DIFF
--- a/lib/core/web_tracker/company_enrichment_job.ex
+++ b/lib/core/web_tracker/company_enrichment_job.ex
@@ -260,6 +260,13 @@ defmodule Core.WebTracker.CompanyEnrichmentJob do
             company_domain: domain
           )
 
+        {:error, :cannot_resolve_url} ->
+          Tracing.warning(
+            :cannot_resolve_url,
+            "Cannot resolve url: #{domain}",
+            company_domain: domain
+          )
+
         {:error, reason} ->
           Tracing.error(reason, "Company not created from webTracker",
             company_domain: domain,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Replaces error log with warning log for `{:error, :cannot_resolve_url}` in `company_enrichment_job.ex`.
> 
>   - **Logging**:
>     - Replaces `Tracing.error` with `Tracing.warning` for `{:error, :cannot_resolve_url}` case in `company_enrichment_job.ex`.
>     - Logs a warning message "Cannot resolve url: #{domain}" with `company_domain` attribute.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for 2467988d584a9073a28acb826ef63fca1df1b28d. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->