### PR TITLE
patch: disqualify lead

### DIFF
--- a/lib/core/crm/contacts.ex
+++ b/lib/core/crm/contacts.ex
@@ -1111,5 +1111,4 @@ defmodule Core.Crm.Contacts do
         {:ok, nil}
     end
   end
-
 end

--- a/lib/core/crm/leads/lead.ex
+++ b/lib/core/crm/leads/lead.ex
@@ -36,6 +36,7 @@ defmodule Core.Crm.Leads.Lead do
           | :revenue_model_mismatch
           | :startup_too_early
           | :unable_to_determine_fit
+          | :user_feedback
           | :wrong_industry
           | :wrong_geography
           | :wrong_business_model
@@ -96,6 +97,7 @@ defmodule Core.Crm.Leads.Lead do
         :revenue_model_mismatch,
         :startup_too_early,
         :unable_to_determine_fit,
+        :user_feedback,
         :wrong_industry,
         :wrong_geography,
         :wrong_business_model

--- a/lib/core/crm/target_personas/target_persona_linkedin_processor.ex
+++ b/lib/core/crm/target_personas/target_persona_linkedin_processor.ex
@@ -202,5 +202,4 @@ defmodule Core.Crm.TargetPersonas.TargetPersonaLinkedinProcessor do
         {:ok, records}
     end
   end
-
 end

--- a/lib/web/controllers/leads_controller.ex
+++ b/lib/web/controllers/leads_controller.ex
@@ -106,6 +106,27 @@ defmodule Web.LeadsController do
     |> send_resp(200, csv_content)
   end
 
+  def disqualify(conn, %{"id" => lead_id}) do
+    %{tenant_id: tenant_id} = conn.assigns.current_user
+
+    case Leads.disqualify_lead(tenant_id, lead_id) do
+      {:ok, lead} ->
+        conn
+        |> put_status(:ok)
+        |> json(%{success: true, lead: lead})
+
+      {:error, :not_found} ->
+        conn
+        |> put_status(:not_found)
+        |> json(%{error: "Lead not found"})
+
+      {:error, reason} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> json(%{error: "Failed to disqualify lead: #{reason}"})
+    end
+  end
+
   defp get_filter_by(params) do
     case params do
       %{"stage" => stage} -> [stage: stage]

--- a/lib/web/router.ex
+++ b/lib/web/router.ex
@@ -118,6 +118,7 @@ defmodule Web.Router do
     scope "/leads" do
       get "/", LeadsController, :index
       get "/download", LeadsController, :download
+      post "/:id/disqualify", LeadsController, :disqualify
     end
 
     scope "/tenants" do


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add lead disqualification feature with `disqualify_lead` function and new endpoint.
> 
>   - **Behavior**:
>     - Adds `disqualify_lead/2` function in `leads.ex` to mark a lead as `:not_a_fit` with reason `:user_feedback`.
>     - Adds `disqualify/2` action in `leads_controller.ex` to handle disqualification requests, returning appropriate JSON responses.
>   - **Models**:
>     - Adds `:user_feedback` to `icp_disqualification_reason` in `Lead` schema in `lead.ex`.
>   - **Routes**:
>     - Adds POST `/leads/:id/disqualify` route in `router.ex` to handle lead disqualification.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for 1433118eb111373e1b0339c618615d3f2a0dd015. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->