### PR TITLE
patch: brief creation

### DIFF
--- a/lib/core/auth/users.ex
+++ b/lib/core/auth/users.ex
@@ -174,7 +174,7 @@ defmodule Core.Auth.Users do
       Web.Endpoint.broadcast("events:#{email}", "event", %{
         type: :icp_fit_evaluation_complete,
         payload: %{
-          is_fit: fit != :not_a_fit
+          is_fit: fit not in [:not_a_fit, :unknown]
         }
       })
     end
@@ -206,6 +206,10 @@ defmodule Core.Auth.Users do
       :not_a_fit ->
         deliver_blocked_user_slack_notification(email)
         add_error(changeset, :lead, "Not a fit")
+
+      :unknown ->
+        deliver_blocked_user_slack_notification(email)
+        add_error(changeset, :lead, "Unknown ICP fit")
 
       :moderate ->
         changeset

--- a/lib/core/crm/leads.ex
+++ b/lib/core/crm/leads.ex
@@ -193,7 +193,7 @@ defmodule Core.Crm.Leads do
       |> where([l], l.stage not in [:pending])
       |> where([l], not is_nil(l.stage))
       |> where([l], not is_nil(l.icp_fit))
-      |> where([l], l.icp_fit != :not_a_fit)
+      |> where([l], l.icp_fit not in [:not_a_fit, :unknown])
       |> order(order_by)
       |> Repo.all()
       |> then(fn

--- a/lib/core/crm/leads/new_lead_pipeline.ex
+++ b/lib/core/crm/leads/new_lead_pipeline.ex
@@ -133,7 +133,7 @@ defmodule Core.Crm.Leads.NewLeadPipeline do
             {"result", fit}
           ])
 
-          {:ok, lead}
+          {:ok, fit}
 
         {:error, reason} ->
           Tracing.error(
@@ -159,6 +159,8 @@ defmodule Core.Crm.Leads.NewLeadPipeline do
   defp execute_callback_if_provided(_, _), do: :ok
 
   defp brief_writer(:not_a_fit, _domain, _lead), do: :ok
+
+  defp brief_writer(:unknown, _domain, _lead), do: :ok
 
   defp brief_writer(fit, domain, %Leads.Lead{} = lead) do
     OpenTelemetry.Tracer.with_span "new_lead_pipeline.brief_writer" do

--- a/lib/core/crm/leads/new_lead_pipeline.ex
+++ b/lib/core/crm/leads/new_lead_pipeline.ex
@@ -22,7 +22,6 @@ defmodule Core.Crm.Leads.NewLeadPipeline do
   alias Core.Crm.Leads
   alias Core.Utils.Tracing
   alias Core.Crm.Leads.Lead
-  alias Core.Researcher.BriefWriter
   alias Core.Researcher.IcpFitEvaluator
 
   def start(lead_id, tenant_id, callback \\ nil, opts \\ []) do
@@ -68,8 +67,7 @@ defmodule Core.Crm.Leads.NewLeadPipeline do
            {:ok, domain} <-
              Leads.get_domain_for_lead_company(tenant_id, lead_id),
            {:ok, fit} <- analyze_icp_fit(domain, lead, opts),
-           :ok <- execute_callback_if_provided(callback, fit),
-           :ok <- brief_writer(fit, domain, lead) do
+           :ok <- execute_callback_if_provided(callback, fit) do
         :ok
       else
         false ->
@@ -157,50 +155,4 @@ defmodule Core.Crm.Leads.NewLeadPipeline do
   end
 
   defp execute_callback_if_provided(_, _), do: :ok
-
-  defp brief_writer(:not_a_fit, _domain, _lead), do: :ok
-
-  defp brief_writer(:unknown, _domain, _lead), do: :ok
-
-  defp brief_writer(fit, domain, %Leads.Lead{} = lead) do
-    OpenTelemetry.Tracer.with_span "new_lead_pipeline.brief_writer" do
-      OpenTelemetry.Tracer.set_attributes([
-        {"param.lead.id", lead.id},
-        {"param.tenant.id", lead.tenant_id},
-        {"param.domain", domain},
-        {"param.icp_fit", fit}
-      ])
-
-      Logger.metadata(module: __MODULE__, function: :brief_writer)
-
-      Logger.info("Writing Account Brief",
-        lead_id: lead.id,
-        url: domain,
-        tenant_id: lead.tenant_id,
-        icp_fit: fit
-      )
-
-      case BriefWriter.create_brief(lead.tenant_id, lead.id, domain) do
-        {:ok, _document} ->
-          :ok
-
-        {:error, :closed_sessions_not_found} ->
-          Tracing.warning(
-            :not_found,
-            "Sessions data not ready for brief creation"
-          )
-
-          {:error, :closed_sessions_not_found}
-
-        {:error, reason} ->
-          Tracing.error(reason, "Account brief creation failed",
-            lead_id: lead.id,
-            url: domain,
-            tenant_id: lead.tenant_id
-          )
-
-          {:error, reason}
-      end
-    end
-  end
 end

--- a/lib/core/researcher/icp_fit_evaluator/validator.ex
+++ b/lib/core/researcher/icp_fit_evaluator/validator.ex
@@ -12,11 +12,12 @@ defmodule Core.Researcher.IcpFitEvaluator.Validator do
   or :not_a_fit) with appropriate disqualification reasons when applicable.
   """
 
-  @valid_fits ["strong", "moderate", "not_a_fit"]
+  @valid_fits ["strong", "moderate", "not_a_fit", "unknown"]
   @fit_atoms %{
     "strong" => :strong,
     "moderate" => :moderate,
-    "not_a_fit" => :not_a_fit
+    "not_a_fit" => :not_a_fit,
+    "unknown" => :unknown
   }
 
   @valid_disqualification_reasons [

--- a/lib/core/web_tracker/channel_classifier.ex
+++ b/lib/core/web_tracker/channel_classifier.ex
@@ -21,7 +21,6 @@ defmodule Core.WebTracker.ChannelClassifier do
   def classify_session(session_id, tenant_domains) do
     case Events.get_first_event(session_id) do
       {:ok, event} ->
-        dbg(event)
         classify(tenant_domains, event.referrer, event.search, event.user_agent)
 
       {:error, :not_found} ->

--- a/lib/core/web_tracker/session_analyzer.ex
+++ b/lib/core/web_tracker/session_analyzer.ex
@@ -76,6 +76,7 @@ defmodule Core.WebTracker.SessionAnalyzer do
       cond do
         lead.stage == :ready_to_buy -> {:stop, :already_ready_to_buy}
         lead.icp_fit == :not_a_fit -> {:stop, :not_icp_fit}
+        lead.icp_fit == :unknown -> {:stop, :unknown_icp_fit}
         true -> {:ok, :proceed}
       end
     else

--- a/lib/web/controllers/leads_controller.ex
+++ b/lib/web/controllers/leads_controller.ex
@@ -182,7 +182,6 @@ defmodule Web.LeadsController do
       :evaluation -> "Evaluation"
       :ready_to_buy -> "Ready to Buy"
       :customer -> "Customer"
-      :not_a_fit -> "Not a Fit"
       :pending -> "Pending"
       nil -> ""
       _ -> stage |> Atom.to_string() |> String.capitalize()


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add handling for `:unknown` ICP fit status across lead processing and evaluation modules.
> 
>   - **Behavior**:
>     - Update ICP fit evaluation to include `:unknown` status in `users.ex`, `leads.ex`, and `validator.ex`.
>     - Modify `handle_lead_icp_fit` in `users.ex` to handle `:unknown` status by adding an error and sending a Slack notification.
>     - Update `list_view_by_tenant_id` in `leads.ex` to exclude `:unknown` ICP fits.
>     - Adjust `fetch_leads_without_briefs` in `brief_creator.ex` to process leads with `:strong` or `:moderate` fits only.
>     - Modify `new_lead_pipeline.ex` to handle `:unknown` status in `handle_error` and `applicable_for_icp_fit?`.
>     - Update `session_analyzer.ex` to stop processing if lead ICP fit is `:unknown`.
>   - **Models**:
>     - Add `:unknown` to `@valid_fits` and `@fit_atoms` in `validator.ex`.
>   - **Misc**:
>     - Remove unused `brief_writer` function in `new_lead_pipeline.ex`.
>     - Remove debug statement in `channel_classifier.ex`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for 067eadc814b915f975e5b0aed9451e12a8819e78. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->