### PR TITLE
patch:fix caching issue for attribution

### DIFF
--- a/assets/src/pages/Leads/Leads.tsx
+++ b/assets/src/pages/Leads/Leads.tsx
@@ -40,22 +40,27 @@ export default function Leads({ leads, stage_counts, max_count }: LeadsProps) {
 
   const handleOpenLead = useCallback(
     (lead: { id: string; stage: Stage }) => {
-      setUrlState(({ lead: currentLead, ...rest }) => {
-        if (lead.id === currentLead) {
+      setUrlState(
+        ({ lead: currentLead, ...rest }) => {
+          if (lead.id === currentLead) {
+            return {
+              ...rest,
+              viewMode: 'default',
+              viewDoc: true,
+            };
+          }
+
           return {
             ...rest,
+            lead: lead.id,
             viewMode: 'default',
             viewDoc: true,
           };
+        },
+        {
+          revalidate: ['personas', 'attribution'],
         }
-
-        return {
-          ...rest,
-          lead: lead.id,
-          viewMode: 'default',
-          viewDoc: true,
-        };
-      });
+      );
     },
     [setUrlState]
   );

--- a/assets/src/pages/Leads/components/ChannelAttribution/ChannelAttribution.tsx
+++ b/assets/src/pages/Leads/components/ChannelAttribution/ChannelAttribution.tsx
@@ -1,4 +1,4 @@
-import { usePage } from '@inertiajs/react';
+import { usePage, WhenVisible } from '@inertiajs/react';
 
 import { match } from 'ts-pattern';
 import { Tooltip } from 'src/components/Tooltip';
@@ -79,9 +79,11 @@ export const ChannelAttribution = () => {
   );
 
   return showTooltip ? (
-    <Tooltip side="bottom" label={tooltipLabel}>
-      {content}
-    </Tooltip>
+    <WhenVisible fallback={<></>} data="attribution">
+      <Tooltip side="bottom" label={tooltipLabel}>
+        {content}
+      </Tooltip>
+    </WhenVisible>
   ) : (
     content
   );

--- a/assets/src/pages/Leads/components/ContextualPanel/ContextualPanel.tsx
+++ b/assets/src/pages/Leads/components/ContextualPanel/ContextualPanel.tsx
@@ -126,7 +126,7 @@ export const ContextualPanel = () => {
         };
       },
       {
-        revalidate: ['personas'],
+        revalidate: ['personas', 'attribution'],
       }
     );
   };


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix caching issue by updating revalidation strategy for attribution in `Leads.tsx`, `ChannelAttribution.tsx`, and `ContextualPanel.tsx`.
> 
>   - **Behavior**:
>     - Updates `handleOpenLead` in `Leads.tsx` to revalidate `personas` and `attribution` when setting URL state.
>     - Wraps `Tooltip` in `ChannelAttribution.tsx` with `WhenVisible` to defer rendering until visible.
>     - Updates `ContextualPanel.tsx` to revalidate `personas` and `attribution` on tab click.
>   - **Imports**:
>     - Adds `WhenVisible` import in `ChannelAttribution.tsx`.
>   - **Misc**:
>     - Updates `ContextualPanel.tsx` to include `attribution` in revalidation list.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for a5dca43788d777db8cf72a2c454f77d943ada199. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->