### PR TITLE
patch: rerun better contact for email

### DIFF
--- a/lib/core/crm/contacts/enricher/better_contact_jobs.ex
+++ b/lib/core/crm/contacts/enricher/better_contact_jobs.ex
@@ -52,7 +52,7 @@ defmodule Core.Crm.Contacts.Enricher.BetterContactJobs do
 
     from(job in BetterContactJob,
       where: job.status == :processing,
-      where: job.next_check_at <= ^now,
+      where: is_nil(job.next_check_at) or job.next_check_at <= ^now,
       order_by: [asc: job.next_check_at]
     )
     |> Repo.all()


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix `get_jobs_ready_for_retry` in `better_contact_jobs.ex` to include jobs with `nil` `next_check_at`.
> 
>   - **Behavior**:
>     - In `better_contact_jobs.ex`, `get_jobs_ready_for_retry` now includes jobs with `nil` `next_check_at` in the retry query.
>     - This change ensures jobs without a scheduled `next_check_at` are processed for retry.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for a737332f2fe09c26249eb6342eac7f6bbd5e6f95. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->