### PR TITLE
patch: fix brief not a fit

### DIFF
--- a/lib/core/crm/documents.ex
+++ b/lib/core/crm/documents.ex
@@ -216,7 +216,10 @@ defmodule Core.Crm.Documents do
       Core.Crm.Documents.YDoc.insert_update(doc_id, output)
     else
       {error_output, _exit_code} ->
-        Logger.error("Error converting lexical state to Yjs: #{inspect(error_output)}")
+        Logger.error(
+          "Error converting lexical state to Yjs: #{inspect(error_output)}"
+        )
+
         {:error, "Could not convert lexical state to Yjs document"}
     end
   end

--- a/lib/core/crm/leads.ex
+++ b/lib/core/crm/leads.ex
@@ -552,7 +552,7 @@ defmodule Core.Crm.Leads do
     result
   end
 
-  def disqualify_lead(tenant_id, lead_id) do
+  def disqualify_lead_by_user(tenant_id, lead_id) do
     OpenTelemetry.Tracer.with_span "leads.disqualify_lead" do
       OpenTelemetry.Tracer.set_attributes([
         {"param.tenant.id", tenant_id},
@@ -572,6 +572,22 @@ defmodule Core.Crm.Leads do
         {:error, reason} ->
           {:error, reason}
       end
+    end
+  end
+
+  def disqualify_lead_by_brief_writer(tenant_id, lead_id) do
+    case get_by_id(tenant_id, lead_id) do
+      {:ok, lead} ->
+        update_lead(
+          lead,
+          %{
+            icp_fit: :not_a_fit,
+            icp_disqualification_reason: [:brief_writer]
+          }
+        )
+
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 

--- a/lib/core/crm/leads/lead.ex
+++ b/lib/core/crm/leads/lead.ex
@@ -24,7 +24,8 @@ defmodule Core.Crm.Leads.Lead do
           | :customer
   @type icp_fit :: :strong | :moderate | :not_a_fit | :unknown
   @type disqualification_reason ::
-          :company_too_small
+          :brief_writer
+          | :company_too_small
           | :company_too_large
           | :company_declining
           | :competitor

--- a/lib/core/researcher/brief_writer/account_researcher.ex
+++ b/lib/core/researcher/brief_writer/account_researcher.ex
@@ -145,6 +145,9 @@ defmodule Core.Researcher.BriefWriter.AccountResearcher do
     Every section should connect back to: "Here's why our solution would matter to THIS specific company's business results."
     If you can't draw that line clearly, you need to dig deeper into their business model and operating challenges.
     Remember: The goal isn't just to show you did research. It's to demonstrate that you understand their business well enough to have a strategic conversation about improving it.
+
+    CRITICALLY IMPORTANT: if at any point in your analysis you determine this company is not an ICP fit, DO NOT generate the brief. Simply return the string below, nothing else:
+      not_a_fit
     """
 
     prompt = """

--- a/lib/web/controllers/leads_controller.ex
+++ b/lib/web/controllers/leads_controller.ex
@@ -135,7 +135,7 @@ defmodule Web.LeadsController do
   def disqualify(conn, %{"id" => lead_id}) do
     %{tenant_id: tenant_id} = conn.assigns.current_user
 
-    case Leads.disqualify_lead(tenant_id, lead_id) do
+    case Leads.disqualify_lead_by_user(tenant_id, lead_id) do
       {:ok, lead} ->
         lead_map =
           Map.take(lead, [


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds functionality to disqualify leads based on brief writer analysis and updates related logic across modules.
> 
>   - **Behavior**:
>     - Adds `disqualify_lead_by_brief_writer()` in `leads.ex` to disqualify leads based on brief writer analysis.
>     - Updates `create_brief()` in `brief_writer.ex` to use `disqualify_lead_by_brief_writer()` when a lead is not a fit.
>     - Modifies `disqualify()` in `leads_controller.ex` to call `disqualify_lead_by_user()`.
>   - **Models**:
>     - Adds `:brief_writer` to `disqualification_reason` in `lead.ex`.
>   - **Misc**:
>     - Renames `disqualify_lead()` to `disqualify_lead_by_user()` in `leads.ex` and `leads_controller.ex`.
>     - Adds `validate_account_overview()` in `brief_writer.ex` to check for "not_a_fit" in account overview.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for 319a016bb479d6b00e82e7461a72e84edda263f3. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->