### PR TITLE
patch: do not report missing sessions as error

### DIFF
--- a/lib/core/researcher/brief_writer/engagement_profiler.ex
+++ b/lib/core/researcher/brief_writer/engagement_profiler.ex
@@ -189,6 +189,14 @@ defmodule Core.Researcher.BriefWriter.EngagementProfiler do
            ) do
       {:ok, sessions}
     else
+      {:error, :closed_sessions_not_found} ->
+        Tracing.warning(
+          :closed_sessions_not_found,
+          "No closed sessions found for lead"
+        )
+
+        {:error, :closed_sessions_not_found}
+
       {:error, reason} ->
         Tracing.error(reason, "Failed to lookup sessions for lead",
           tenant_id: tenant_id,

--- a/lib/core/web_tracker/channel_classifier.ex
+++ b/lib/core/web_tracker/channel_classifier.ex
@@ -136,8 +136,8 @@ defmodule Core.WebTracker.ChannelClassifier do
       QueryParamAnalyzer.has_utm_params?(query_params) -> false
       is_nil(referrer) or referrer == "" -> true
       self_referral?(tenant_domains, referrer) -> true
-      is_amp_self_referral?(referrer, tenant_domains) -> true
-      is_internal_tool_referrer?(referrer) -> true
+      amp_self_referral?(referrer, tenant_domains) -> true
+      internal_tool_referrer?(referrer) -> true
       true -> false
     end
   end
@@ -174,7 +174,7 @@ defmodule Core.WebTracker.ChannelClassifier do
     end
   end
 
-  defp is_amp_self_referral?(referrer, tenant_domains) do
+  defp amp_self_referral?(referrer, tenant_domains) do
     case URI.parse(referrer || "") do
       %URI{host: host} when is_binary(host) ->
         String.contains?(host, "ampproject.org") and
@@ -187,7 +187,7 @@ defmodule Core.WebTracker.ChannelClassifier do
     end
   end
 
-  defp is_internal_tool_referrer?(referrer) do
+  defp internal_tool_referrer?(referrer) do
     hubspot_internal_patterns = [
       "hubspotpreview-na1.com",
       "hubspotpreview-eu1.com",

--- a/lib/core/web_tracker/email_detector.ex
+++ b/lib/core/web_tracker/email_detector.ex
@@ -2,8 +2,8 @@ defmodule Core.WebTracker.EmailDetector do
   @moduledoc """
   Detects email platform traffic and distinguishes between marketing emails and personal email shares.
 
-  This module analyzes referrer URLs and query parameters to identify email service 
-  providers (Mailchimp, Klaviyo, Gmail, etc.) and determine whether traffic comes 
+  This module analyzes referrer URLs and query parameters to identify email service
+  providers (Mailchimp, Klaviyo, Gmail, etc.) and determine whether traffic comes
   from marketing email campaigns, transactional emails, or personal email shares.
   """
 
@@ -170,7 +170,7 @@ defmodule Core.WebTracker.EmailDetector do
   """
   def email_traffic?(referrer, query_params) do
     cond do
-      is_mobile_email_app?(referrer) -> true
+      mobile_email_app?(referrer) -> true
       has_email_utm_medium?(query_params) -> true
       has_email_referrer?(referrer) -> true
       has_email_tracking_params?(query_params) -> true
@@ -249,7 +249,7 @@ defmodule Core.WebTracker.EmailDetector do
   """
   def get_platform(referrer, query_params \\ nil) do
     cond do
-      is_mobile_email_app?(referrer) ->
+      mobile_email_app?(referrer) ->
         {:ok, get_mobile_email_platform(referrer)}
 
       true ->
@@ -469,7 +469,7 @@ defmodule Core.WebTracker.EmailDetector do
     "mc_cid" => :mailchimp,
     "mc_eid" => :mailchimp,
 
-    # Klaviyo  
+    # Klaviyo
     "_ke" => :klaviyo,
     "kx" => :klaviyo,
 
@@ -509,11 +509,11 @@ defmodule Core.WebTracker.EmailDetector do
 
   # Private helper functions
 
-  defp is_mobile_email_app?(referrer) when is_binary(referrer) do
+  defp mobile_email_app?(referrer) when is_binary(referrer) do
     Map.has_key?(@mobile_email_apps, referrer)
   end
 
-  defp is_mobile_email_app?(_), do: false
+  defp mobile_email_app?(_), do: false
 
   defp get_mobile_email_platform(referrer) when is_binary(referrer) do
     Map.get(@mobile_email_apps, referrer, :unknown_email_app)

--- a/lib/core/web_tracker/search_platform_detector.ex
+++ b/lib/core/web_tracker/search_platform_detector.ex
@@ -418,7 +418,7 @@ defmodule Core.WebTracker.SearchPlatformDetector do
     utm_medium in @search_mediums and
       (Map.has_key?(@utm_source_mapping, utm_source) or
          has_search_source_keywords?(utm_source)) and
-      not is_social_source?(utm_source)
+      not social_source?(utm_source)
   end
 
   defp has_search_source_keywords?(utm_source) do
@@ -437,7 +437,7 @@ defmodule Core.WebTracker.SearchPlatformDetector do
     end)
   end
 
-  defp is_social_source?(utm_source) do
+  defp social_source?(utm_source) do
     social_keywords = [
       "linkedin",
       "facebook",
@@ -473,7 +473,7 @@ defmodule Core.WebTracker.SearchPlatformDetector do
   def get_platform_from_referrer(referrer) do
     cond do
       # Check for mobile app referrers first
-      is_mobile_app_referrer?(referrer) ->
+      mobile_app_referrer?(referrer) ->
         get_platform_from_mobile_app(referrer)
 
       # Then check regular web domains
@@ -491,12 +491,12 @@ defmodule Core.WebTracker.SearchPlatformDetector do
     end
   end
 
-  defp is_mobile_app_referrer?(referrer) when is_binary(referrer) do
+  defp mobile_app_referrer?(referrer) when is_binary(referrer) do
     String.starts_with?(referrer, "android-app://") or
       String.starts_with?(referrer, "ios-app://")
   end
 
-  defp is_mobile_app_referrer?(_), do: false
+  defp mobile_app_referrer?(_), do: false
 
   defp get_platform_from_mobile_app(referrer) do
     # Remove trailing slash for consistent matching

--- a/lib/core/web_tracker/sessions.ex
+++ b/lib/core/web_tracker/sessions.ex
@@ -106,10 +106,10 @@ defmodule Core.WebTracker.Sessions do
   @doc """
   Returns all closed sessions for a lead
   """
-  def get_all_closed_sessions_by_tenant_and_company(tenant, company_id) do
+  def get_all_closed_sessions_by_tenant_and_company(tenant_name, company_id) do
     from(s in Session,
       where:
-        s.tenant == ^tenant and s.company_id == ^company_id and
+        s.tenant == ^tenant_name and s.company_id == ^company_id and
           s.active == false
     )
     |> Repo.all()

--- a/lib/core/web_tracker/social_platform_detector.ex
+++ b/lib/core/web_tracker/social_platform_detector.ex
@@ -2,9 +2,9 @@ defmodule Core.WebTracker.SocialPlatformDetector do
   @moduledoc """
   Detects social platforms and distinguishes between paid and organic social traffic.
 
-  This module analyzes referrer URLs, query parameters, and user agent strings to 
-  identify social media platforms (Facebook, Instagram, Twitter, LinkedIn, etc.) 
-  and determine whether traffic comes from paid advertising campaigns or organic 
+  This module analyzes referrer URLs, query parameters, and user agent strings to
+  identify social media platforms (Facebook, Instagram, Twitter, LinkedIn, etc.)
+  and determine whether traffic comes from paid advertising campaigns or organic
   social media posts.
   """
 
@@ -724,7 +724,7 @@ defmodule Core.WebTracker.SocialPlatformDetector do
   defp get_platform_from_referrer(referrer) do
     cond do
       # Check for mobile app referrers first
-      is_mobile_app_referrer?(referrer) ->
+      mobile_app_referrer?(referrer) ->
         get_platform_from_mobile_app(referrer)
 
       true ->
@@ -873,12 +873,12 @@ defmodule Core.WebTracker.SocialPlatformDetector do
     end
   end
 
-  defp is_mobile_app_referrer?(referrer) when is_binary(referrer) do
+  defp mobile_app_referrer?(referrer) when is_binary(referrer) do
     String.starts_with?(referrer, "android-app://") or
       String.starts_with?(referrer, "ios-app://")
   end
 
-  defp is_mobile_app_referrer?(_), do: false
+  defp mobile_app_referrer?(_), do: false
 
   defp get_platform_from_mobile_app(referrer) do
     clean_referrer = String.trim_trailing(referrer, "/")


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> The PR logs missing closed sessions as warnings and renames several functions for consistency across multiple files.
> 
>   - **Behavior**:
>     - In `engagement_profiler.ex`, missing closed sessions for a lead are logged as a warning instead of an error.
>   - **Function Renames**:
>     - Renames `is_amp_self_referral?` to `amp_self_referral?` and `is_internal_tool_referrer?` to `internal_tool_referrer?` in `channel_classifier.ex`.
>     - Renames `is_mobile_email_app?` to `mobile_email_app?` in `email_detector.ex`.
>     - Renames `is_social_source?` to `social_source?` and `is_mobile_app_referrer?` to `mobile_app_referrer?` in `search_platform_detector.ex`.
>   - **Misc**:
>     - Minor whitespace cleanup in `email_detector.ex`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for 1a7e37e7fe37da1e9813d744879bf588569be0f3. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->