### PR TITLE
patch: ip is threat do not report as error

### DIFF
--- a/lib/core/web_tracker/events.ex
+++ b/lib/core/web_tracker/events.ex
@@ -110,27 +110,19 @@ defmodule Core.WebTracker.Events do
             |> put_change(:session_id, session.id)
             |> put_change(:with_new_session, session.just_created)
 
-          {:error, reason} when is_binary(reason) ->
-            case reason do
-              :ip_is_threat ->
-                Tracing.warning(
-                  :ip_is_threat,
-                  "IP is threat, skipping session creation"
-                )
-
-              _ ->
-                Tracing.error(reason, "Failed to create/get session")
-            end
-
-            add_error(changeset, :session_id, reason)
-
-          {:error, %Ecto.Changeset{}} ->
-            Tracing.error(
-              "changeset_error",
-              "Failed to create/get session with changeset error"
+          {:error, :ip_is_threat} ->
+            Tracing.warning(
+              :ip_is_threat,
+              "IP is threat, skipping session creation"
             )
 
-            add_error(changeset, :session_id, "session_creation_failed")
+            add_error(changeset, :session_id, :ip_is_threat)
+
+          {:error, changeset} ->
+            Tracing.error(
+              changeset.errors,
+              "Failed to create/get session with changeset error"
+            )
 
           {:error, reason} ->
             Tracing.error(reason, "Failed to create/get session")


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> In `events.ex`, the `:ip_is_threat` error is now logged as a warning, and error handling in `maybe_put_session_id()` is consolidated.
> 
>   - **Behavior**:
>     - In `events.ex`, `:ip_is_threat` error is now logged as a warning instead of an error in `maybe_put_session_id()`.
>     - Removes handling of binary `reason` for `:ip_is_threat`, now specifically handled as an atom.
>   - **Error Handling**:
>     - Consolidates error handling for changeset errors in `maybe_put_session_id()`.
>     - Removes redundant case for `%Ecto.Changeset{}` errors, now handled in a single clause.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for 0fe56e38ed7f1def788c3dd7cfe159d6e81f5970. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->