### PR TITLE
patch: move webtracker origin whitelist to db

### DIFF
--- a/lib/core/auth/tenants.ex
+++ b/lib/core/auth/tenants.ex
@@ -54,6 +54,19 @@ defmodule Core.Auth.Tenants do
 
   def get_tenant_domains(_tenant_id), do: @err_invalid_tenant_id
 
+  def get_tenant_by_domain(domain) do
+    query =
+      from t in Tenant,
+        where:
+          t.primary_domain == ^domain or
+            fragment("? = ANY(?)", ^domain, t.domains)
+
+    case Repo.one(query) do
+      nil -> @err_not_found
+      tenant -> {:ok, tenant}
+    end
+  end
+
   def get_all_tenant_ids do
     case Repo.all(from t in Tenant, select: t.id) do
       [] -> @err_not_found


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Move origin whitelist from hardcoded map to database query in `origin_tenant_mapper.ex`, adding `get_tenant_by_domain` in `tenants.ex`.
> 
>   - **Behavior**:
>     - Replaces hardcoded origin whitelist in `origin_tenant_mapper.ex` with database query using `get_tenant_by_domain` from `tenants.ex`.
>     - Blocks origins with subdomains `careers` and `jobs` in `check_subdomain_tenant()` in `origin_tenant_mapper.ex`.
>   - **Functions**:
>     - Adds `get_tenant_by_domain(domain)` in `tenants.ex` to fetch tenant by domain from the database.
>     - Updates `find_tenant_for_domain(domain)` in `origin_tenant_mapper.ex` to use `get_tenant_by_domain`.
>   - **Errors**:
>     - Introduces `@err_origin_blocked` in `origin_tenant_mapper.ex` for blocked subdomains.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for 146fa33e2f98e24a1c7d74a28f29bb09e5a53d1f. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->