### PR TITLE
patch: google ads oauth

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -243,15 +243,10 @@ config :core, :hubspot,
 config :core, :google_ads,
   client_id: System.get_env("GOOGLE_ADS_CLIENT_ID"),
   client_secret: System.get_env("GOOGLE_ADS_CLIENT_SECRET"),
-  scopes:
-    String.split(
-      System.get_env(
-        "GOOGLE_ADS_SCOPES",
-        "https://www.googleapis.com/auth/adwords"
-      ),
-      " "
-    ),
+  developer_token: System.get_env("GOOGLE_ADS_DEVELOPER_TOKEN"),
+  scopes: String.split(System.get_env("GOOGLE_ADS_SCOPES", "https://www.googleapis.com/auth/adwords"), " "),
   api_base_url: "https://googleads.googleapis.com/v14",
+  api_base_url_no_version: "https://googleads.googleapis.com",
   auth_base_url: "https://accounts.google.com",
   token_base_url: "https://oauth2.googleapis.com"
 

--- a/lib/core/integrations/providers/google_ads/campaigns.ex
+++ b/lib/core/integrations/providers/google_ads/campaigns.ex
@@ -32,7 +32,7 @@ defmodule Core.Integrations.Providers.GoogleAds.Campaigns do
         }
       ]}
   """
-  def list_campaigns(%Connection{} = connection) do
+    def list_campaigns(%Connection{} = connection) do
     customer_id = connection.external_system_id
 
     case Client.get(

--- a/lib/core/integrations/providers/google_ads/client.ex
+++ b/lib/core/integrations/providers/google_ads/client.ex
@@ -26,6 +26,20 @@ defmodule Core.Integrations.Providers.GoogleAds.Client do
   end
 
   @doc """
+  Gets the base URL for Google Ads API calls without version prefix.
+  """
+  def base_url_no_version do
+    config = Application.get_env(:core, :google_ads)
+    base_url = config[:api_base_url_no_version]
+
+    unless base_url do
+      raise "Google Ads api_base_url_no_version is not configured. Please set it in your runtime config."
+    end
+
+    base_url
+  end
+
+  @doc """
   Makes a GET request to the Google Ads API.
 
   This function:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhance Google Ads OAuth integration with new configurations, improved token validation, and better error handling across multiple modules.
> 
>   - **Configuration**:
>     - Add `developer_token` and `api_base_url_no_version` to Google Ads config in `runtime.exs`.
>   - **OAuth Provider**:
>     - Update `validate_token()` in `google_ads.ex` to use `token_base_url`.
>     - Rename `get_account_info()` to `get_customer_id()` and update logic to use `customers:listAccessibleCustomers` endpoint.
>     - Add `make_http_get_with_headers()` for requests with headers.
>   - **Client**:
>     - Add `base_url_no_version()` in `client.ex` for non-versioned API calls.
>   - **Controller**:
>     - Update `handle_successful_oauth()` in `google_ads_controller.ex` to handle `:no_customers_found` error.
>     - Improve error logging and flash messages for OAuth flow.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for 6516e93eed8b3d849fe1c9eb1172edff724ae7ba. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->