### PR TITLE
patch: fix stuck analytics job

### DIFF
--- a/lib/core/analytics/analytics_jobs.ex
+++ b/lib/core/analytics/analytics_jobs.ex
@@ -8,6 +8,7 @@ defmodule Core.Analytics.AnalyticsJobs do
   alias Core.Analytics.AnalyticsJob
 
   @err_create_job {:error, "failed to create analytics job"}
+  @err_not_found {:error, "job not found"}
 
   def create_job(tenant_id, job_type, scheduled_for_utc) do
     %{
@@ -31,6 +32,13 @@ defmodule Core.Analytics.AnalyticsJobs do
         )
 
         @err_create_job
+    end
+  end
+
+  def get_by_id(job_id) do
+    case Repo.get_by(AnalyticsJob, id: job_id) do
+      nil -> @err_not_found
+      %AnalyticsJob{} = job -> {:ok, job}
     end
   end
 

--- a/lib/core/analytics/builder.ex
+++ b/lib/core/analytics/builder.ex
@@ -26,7 +26,7 @@ defmodule Core.Analytics.Builder do
            get_unique_new_companies(tenant_id, start_time_utc, end_time_utc),
          {:ok, new_leads} <-
            get_new_icp_fit_leads(tenant_id, start_time_utc, end_time_utc) do
-      LeadGeneration.create(%{
+      LeadGeneration.upsert(%{
         bucket_start_at: start_time_utc,
         tenant_id: tenant_id,
         sessions: sessions.sessions,

--- a/lib/core/analytics/job_processor.ex
+++ b/lib/core/analytics/job_processor.ex
@@ -106,7 +106,7 @@ defmodule Core.Analytics.JobProcessor do
     end)
   end
 
-  defp execute_job(%AnalyticsJob{job_type: :hourly_lead_generation_agg} = job) do
+  def execute_job(%AnalyticsJob{job_type: :hourly_lead_generation_agg} = job) do
     Logger.info("Processing job #{job.id} for tenant #{job.tenant_id}")
 
     start_hour = truncate_to_hour(DateTime.add(job.scheduled_at, -1, :hour))

--- a/lib/core/web_tracker/origin_tenant_mapper.ex
+++ b/lib/core/web_tracker/origin_tenant_mapper.ex
@@ -30,7 +30,6 @@ defmodule Core.WebTracker.OriginTenantMapper do
 
   defp find_tenant_for_domain(domain) do
     case Tenants.get_tenant_by_domain(domain) do
-      nil -> @err_origin_not_configured
       {:error, "tenant not found"} -> @err_origin_not_configured
       tenant -> {:ok, tenant}
     end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix stuck analytics job by adding error handling, switching to `upsert`, and making `execute_job` public.
> 
>   - **Behavior**:
>     - Add `get_by_id/1` in `analytics_jobs.ex` to fetch jobs by ID, returning `{:error, "job not found"}` if not found.
>     - Change `LeadGeneration.create` to `LeadGeneration.upsert` in `builder.ex` to prevent duplicate records.
>     - Make `execute_job/1` public in `job_processor.ex` for external access.
>   - **Error Handling**:
>     - Add `@err_not_found` in `analytics_jobs.ex` for missing job IDs.
>     - Remove redundant `nil` case in `origin_tenant_mapper.ex` for tenant lookup.
>   - **Misc**:
>     - Minor logging adjustments in `job_processor.ex`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for 5b870bc714daefff3948992e350a732d835477ad. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->