### PR TITLE
patch: deprecate tenant column in sessions and events

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -244,7 +244,14 @@ config :core, :google_ads,
   client_id: System.get_env("GOOGLE_ADS_CLIENT_ID"),
   client_secret: System.get_env("GOOGLE_ADS_CLIENT_SECRET"),
   developer_token: System.get_env("GOOGLE_ADS_DEVELOPER_TOKEN"),
-  scopes: String.split(System.get_env("GOOGLE_ADS_SCOPES", "https://www.googleapis.com/auth/adwords"), " "),
+  scopes:
+    String.split(
+      System.get_env(
+        "GOOGLE_ADS_SCOPES",
+        "https://www.googleapis.com/auth/adwords"
+      ),
+      " "
+    ),
   api_base_url: "https://googleads.googleapis.com/v14",
   api_base_url_no_version: "https://googleads.googleapis.com",
   auth_base_url: "https://accounts.google.com",

--- a/lib/core/analytics/builder.ex
+++ b/lib/core/analytics/builder.ex
@@ -4,7 +4,6 @@ defmodule Core.Analytics.Builder do
 
   alias Core.Repo
   alias Core.Crm.Leads.Lead
-  alias Core.Auth.Tenants.Tenant
   alias Core.Analytics.LeadGeneration
   alias Core.WebTracker.Sessions.Session
 
@@ -56,10 +55,8 @@ defmodule Core.Analytics.Builder do
   def get_sessions(tenant_id, start_time_utc, end_time_utc) do
     results =
       from(ws in Session,
-        join: t in Tenant,
-        on: ws.tenant == t.name,
         where:
-          t.id == ^tenant_id and
+          ws.tenant_id == ^tenant_id and
             ws.started_at >= ^start_time_utc and
             ws.started_at < ^end_time_utc and
             ws.active == false,
@@ -84,12 +81,10 @@ defmodule Core.Analytics.Builder do
   def get_icp_qualified_sessions(tenant_id, start_time_utc, end_time_utc) do
     results =
       from(ws in Session,
-        join: t in Tenant,
-        on: ws.tenant == t.name,
         join: l in Lead,
-        on: l.tenant_id == t.id and l.ref_id == ws.company_id,
+        on: l.tenant_id == ws.tenant_id and l.ref_id == ws.company_id,
         where:
-          t.id == ^tenant_id and
+          ws.tenant_id == ^tenant_id and
             ws.started_at >= ^start_time_utc and
             ws.started_at < ^end_time_utc and
             ws.active == false and
@@ -114,10 +109,8 @@ defmodule Core.Analytics.Builder do
   def get_unique_companies(tenant_id, start_time_utc, end_time_utc) do
     results =
       from(ws in Session,
-        join: t in Tenant,
-        on: ws.tenant == t.name,
         where:
-          t.id == ^tenant_id and
+          ws.tenant_id == ^tenant_id and
             ws.started_at >= ^start_time_utc and
             ws.started_at < ^end_time_utc and
             ws.active == false and
@@ -147,10 +140,8 @@ defmodule Core.Analytics.Builder do
 
     results =
       from(ws in Session,
-        join: t in Tenant,
-        on: ws.tenant == t.name,
         where:
-          t.id == ^tenant_id and
+          ws.tenant_id == ^tenant_id and
             ws.started_at >= ^start_time_utc and
             ws.started_at < ^end_time_utc and
             ws.active == false and
@@ -175,10 +166,8 @@ defmodule Core.Analytics.Builder do
   def get_new_icp_fit_leads(tenant_id, start_time_utc, end_time_utc) do
     results =
       from(l in Lead,
-        join: t in Tenant,
-        on: l.tenant_id == t.id,
         where:
-          t.id == ^tenant_id and
+          l.tenant_id == ^tenant_id and
             l.inserted_at >= ^start_time_utc and
             l.inserted_at < ^end_time_utc and
             l.icp_fit in [:strong, :moderate] and

--- a/lib/core/crm/leads.ex
+++ b/lib/core/crm/leads.ex
@@ -131,29 +131,29 @@ defmodule Core.Crm.Leads do
   Returns channel (first touch) attribution for a lead.
   returns {:ok, :channel, :platform, "referrer"} or {:error, reason}
   """
-
   def get_channel_attribution(tenant_id, lead_id) do
-    with {:ok, tenant} <- Tenants.get_tenant_by_id(tenant_id),
-         {:ok, lead} <- get_by_id(tenant_id, lead_id) do
-      from(s in Session,
-        where: s.company_id == ^lead.ref_id and s.tenant == ^tenant.name,
-        order_by: [asc: s.inserted_at],
-        select: %{
-          id: s.id,
-          channel: s.channel,
-          platform: s.platform,
-          referrer: s.referrer,
-          city: s.city,
-          country_code: s.country_code,
-          inserted_at: s.inserted_at
-        }
-      )
-      |> Repo.all()
-      |> Enum.map(fn session ->
-        struct(AttributionView, session)
-      end)
-    else
-      _ -> []
+    case get_by_id(tenant_id, lead_id) do
+      {:ok, lead} ->
+        from(s in Session,
+          where: s.company_id == ^lead.ref_id and s.tenant_id == ^tenant_id,
+          order_by: [asc: s.inserted_at],
+          select: %{
+            id: s.id,
+            channel: s.channel,
+            platform: s.platform,
+            referrer: s.referrer,
+            city: s.city,
+            country_code: s.country_code,
+            inserted_at: s.inserted_at
+          }
+        )
+        |> Repo.all()
+        |> Enum.map(fn session ->
+          struct(AttributionView, session)
+        end)
+
+      _ ->
+        []
     end
   end
 

--- a/lib/core/crm/leads/lead_creator_job.ex
+++ b/lib/core/crm/leads/lead_creator_job.ex
@@ -114,7 +114,7 @@ defmodule Core.Crm.Leads.LeadCreator do
         with {:ok, db_company} <-
                Companies.get_or_create_by_domain(lead_domain_queue.domain),
              {:ok, lead} <-
-               Leads.get_or_create_with_tenant_id(
+               Leads.get_or_create(
                  lead_domain_queue.tenant_id,
                  %{
                    type: :company,

--- a/lib/core/integrations/oauth/providers/google_ads.ex
+++ b/lib/core/integrations/oauth/providers/google_ads.ex
@@ -161,7 +161,7 @@ defmodule Core.Integrations.OAuth.Providers.GoogleAds do
     end
   end
 
-      @doc """
+  @doc """
   Gets Google Ads customer ID using the access token.
   Returns the customer_id for the authenticated user.
 
@@ -170,12 +170,15 @@ defmodule Core.Integrations.OAuth.Providers.GoogleAds do
   """
   def get_customer_id(access_token) do
     # Use the correct Google Ads API endpoint for listing accessible customers (non-versioned)
-    base_url = Core.Integrations.Providers.GoogleAds.Client.base_url_no_version()
+    base_url =
+      Core.Integrations.Providers.GoogleAds.Client.base_url_no_version()
+
     url = "#{base_url}/customers:listAccessibleCustomers"
 
     headers = [
       {"authorization", "Bearer #{access_token}"},
-      {"developer-token", Application.get_env(:core, :google_ads)[:developer_token]}
+      {"developer-token",
+       Application.get_env(:core, :google_ads)[:developer_token]}
     ]
 
     case make_http_get_with_headers(url, headers) do

--- a/lib/core/integrations/providers/google_ads/campaigns.ex
+++ b/lib/core/integrations/providers/google_ads/campaigns.ex
@@ -32,7 +32,7 @@ defmodule Core.Integrations.Providers.GoogleAds.Campaigns do
         }
       ]}
   """
-    def list_campaigns(%Connection{} = connection) do
+  def list_campaigns(%Connection{} = connection) do
     customer_id = connection.external_system_id
 
     case Client.get(

--- a/lib/core/researcher/brief_writer/engagement_profiler.ex
+++ b/lib/core/researcher/brief_writer/engagement_profiler.ex
@@ -6,7 +6,6 @@ defmodule Core.Researcher.BriefWriter.EngagementProfiler do
   require Logger
   alias Core.Ai
   alias Core.Crm.Leads
-  alias Core.Auth.Tenants
   alias Core.Crm.Companies
   alias Core.Utils.TaskAwaiter
   alias Core.WebTracker.Events
@@ -181,14 +180,10 @@ defmodule Core.Researcher.BriefWriter.EngagementProfiler do
   end
 
   defp get_all_sessions_for_lead(tenant_id, company_id) do
-    with {:ok, tenant} <- Tenants.get_tenant_by_id(tenant_id),
-         {:ok, sessions} <-
-           Sessions.get_all_closed_sessions_by_tenant_and_company(
-             tenant.name,
-             company_id
-           ) do
-      {:ok, sessions}
-    else
+    case Sessions.get_all_closed_sessions_by_tenant_and_company(tenant_id, company_id) do
+      {:ok, sessions} ->
+        {:ok, sessions}
+
       {:error, :closed_sessions_not_found} ->
         Tracing.warning(
           :closed_sessions_not_found,

--- a/lib/core/web_tracker/channel_classifier.ex
+++ b/lib/core/web_tracker/channel_classifier.ex
@@ -24,7 +24,8 @@ defmodule Core.WebTracker.ChannelClassifier do
   def classify_session(session_id) do
     with {:ok, session} <- Sessions.get_session_by_id(session_id),
          {:ok, event} <- Events.get_first_event(session_id),
-         {:ok, tenant_domains} when not is_nil(session.tenant_id) <- Tenants.get_tenant_domains(session.tenant_id) do
+         {:ok, tenant_domains} when not is_nil(session.tenant_id) <-
+           Tenants.get_tenant_domains(session.tenant_id) do
       referrer = event.referrer |> to_string() |> String.trim_trailing("/")
 
       classification =

--- a/lib/core/web_tracker/channel_classifier.ex
+++ b/lib/core/web_tracker/channel_classifier.ex
@@ -23,10 +23,8 @@ defmodule Core.WebTracker.ChannelClassifier do
 
   def classify_session(session_id) do
     with {:ok, session} <- Sessions.get_session_by_id(session_id),
-         {:ok, tenant} <- Tenants.get_tenant_by_name(session.tenant),
          {:ok, event} <- Events.get_first_event(session_id),
-         {:ok, tenant_domains} <-
-           Tenants.get_tenant_domains(tenant.id) do
+         {:ok, tenant_domains} when not is_nil(session.tenant_id) <- Tenants.get_tenant_domains(session.tenant_id) do
       referrer = event.referrer |> to_string() |> String.trim_trailing("/")
 
       classification =

--- a/lib/core/web_tracker/company_enrichment_job.ex
+++ b/lib/core/web_tracker/company_enrichment_job.ex
@@ -153,7 +153,7 @@ defmodule Core.WebTracker.CompanyEnrichmentJob do
          {:ok, _session} <-
            Sessions.set_company_id(event.session_id, db_company.id),
          {:ok, _lead} <-
-           Leads.get_or_create(event.tenant, %{
+           Leads.get_or_create(event.tenant_id, %{
              type: :company,
              ref_id: db_company.id
            }) do
@@ -223,16 +223,16 @@ defmodule Core.WebTracker.CompanyEnrichmentJob do
   defp process_company_data(event, domain) do
     OpenTelemetry.Tracer.with_span "company_enrichment_job.process_company_data" do
       OpenTelemetry.Tracer.set_attributes([
-        {"company.domain", domain},
-        {"event.session_id", event.session_id},
-        {"event.tenant", event.tenant}
+        {"param.domain", domain},
+        {"param.session_id", event.session_id},
+        {"param.tenant.id", event.tenant_id}
       ])
 
       with {:ok, db_company} <- Companies.get_or_create_by_domain(domain),
            {:ok, _session} <-
              Sessions.set_company_id(event.session_id, db_company.id),
            {:ok, _lead} <-
-             Leads.get_or_create(event.tenant, %{
+             Leads.get_or_create(event.tenant_id, %{
                type: :company,
                ref_id: db_company.id
              }) do

--- a/lib/core/web_tracker/events/event.ex
+++ b/lib/core/web_tracker/events/event.ex
@@ -22,7 +22,6 @@ defmodule Core.WebTracker.Events.Event do
 
   schema "web_tracker_events" do
     # Required fields
-    field(:tenant, :string) #deprecated
     field(:tenant_id, :string)
     field(:session_id, :string)
 
@@ -51,7 +50,6 @@ defmodule Core.WebTracker.Events.Event do
 
   @type t :: %__MODULE__{
           id: String.t(),
-          tenant: String.t() | nil,
           tenant_id: String.t() | nil,
           session_id: String.t(),
           ip: String.t() | nil,
@@ -100,7 +98,6 @@ defmodule Core.WebTracker.Events.Event do
       :cookies_enabled,
       :screen_resolution,
       :with_new_session,
-      :tenant,
       :tenant_id
     ])
     |> put_id(attrs)
@@ -122,14 +119,12 @@ defmodule Core.WebTracker.Events.Event do
 
   def put_tenant(changeset, attrs) do
     case OriginTenantMapper.get_tenant_for_origin(attrs[:origin]) do
-      {:ok, %Core.Auth.Tenants.Tenant{id: tenant_id, name: tenant_name}} ->
+      {:ok, %Core.Auth.Tenants.Tenant{id: tenant_id}} ->
         changeset
         |> put_change(:tenant_id, tenant_id)
-        |> put_change(:tenant, tenant_name)
 
       {:error, _} ->
         changeset
-        |> put_change(:tenant, nil)
         |> add_error(:origin, "Invalid origin")
     end
   end

--- a/lib/core/web_tracker/events/event.ex
+++ b/lib/core/web_tracker/events/event.ex
@@ -22,7 +22,7 @@ defmodule Core.WebTracker.Events.Event do
 
   schema "web_tracker_events" do
     # Required fields
-    field(:tenant, :string)
+    field(:tenant, :string) #deprecated
     field(:tenant_id, :string)
     field(:session_id, :string)
 
@@ -51,7 +51,7 @@ defmodule Core.WebTracker.Events.Event do
 
   @type t :: %__MODULE__{
           id: String.t(),
-          tenant: String.t(),
+          tenant: String.t() | nil,
           tenant_id: String.t() | nil,
           session_id: String.t(),
           ip: String.t() | nil,
@@ -114,7 +114,6 @@ defmodule Core.WebTracker.Events.Event do
       :href,
       :origin,
       :user_agent,
-      :tenant,
       :tenant_id
     ])
     |> detect_bot()

--- a/lib/core/web_tracker/ip_identifier.ex
+++ b/lib/core/web_tracker/ip_identifier.ex
@@ -118,7 +118,7 @@ defmodule Core.WebTracker.IpIdentifier do
     end
   end
 
-  defp build_ip_intelligence_attrs(domain, default_domain) do
+  defp  (domain, default_domain) do
     %{
       domain: domain || default_domain,
       domain_source: determine_domain_source(domain),

--- a/lib/core/web_tracker/ip_identifier.ex
+++ b/lib/core/web_tracker/ip_identifier.ex
@@ -118,7 +118,7 @@ defmodule Core.WebTracker.IpIdentifier do
     end
   end
 
-  defp  (domain, default_domain) do
+  defp build_ip_intelligence_attrs(domain, default_domain) do
     %{
       domain: domain || default_domain,
       domain_source: determine_domain_source(domain),

--- a/lib/core/web_tracker/session_closer.ex
+++ b/lib/core/web_tracker/session_closer.ex
@@ -121,9 +121,9 @@ defmodule Core.WebTracker.SessionCloser do
   defp close_session(session) do
     OpenTelemetry.Tracer.with_span "web_session_closer.close_session" do
       OpenTelemetry.Tracer.set_attributes([
-        {"session.id", session.id},
-        {"session.tenant", session.tenant},
-        {"session.visitor_id", session.visitor_id}
+        {"param.session.id", session.id},
+        {"param.session.tenant_id", session.tenant_id},
+        {"param.session.visitor_id", session.visitor_id}
       ])
 
       case Sessions.close(session) do

--- a/lib/core/web_tracker/sessions.ex
+++ b/lib/core/web_tracker/sessions.ex
@@ -8,7 +8,6 @@ defmodule Core.WebTracker.Sessions do
 
   alias Core.Repo
   alias Plug.Session
-  alias Core.Auth.Tenants
   alias Core.Utils.IdGenerator
   alias Core.WebTracker.IPProfiler
   alias Core.WebTracker.Sessions.Session
@@ -94,14 +93,7 @@ defmodule Core.WebTracker.Sessions do
     result
   end
 
-  def get_tenant_id_for_session(session_id) do
-    with {:ok, session} <- get_session_by_id(session_id),
-         {:ok, tenant} <- Tenants.get_tenant_by_name(session.tenant) do
-      {:ok, tenant.id}
-    else
-      {:error, reason} -> {:error, reason}
-    end
-  end
+
 
   @doc """
   Returns all closed sessions for a lead

--- a/lib/core/web_tracker/sessions.ex
+++ b/lib/core/web_tracker/sessions.ex
@@ -48,7 +48,7 @@ defmodule Core.WebTracker.Sessions do
   Returns an existing active session if found, or creates a new one.
   """
   def get_or_create_session(event) when is_map(event) do
-    case get_active_session(event.tenant, event.visitor_id, event.origin) do
+    case get_active_session(event.tenant_id, event.visitor_id, event.origin) do
       nil ->
         create_new_session_with_ip_validation(event)
 
@@ -74,15 +74,15 @@ defmodule Core.WebTracker.Sessions do
   end
 
   @doc """
-  Gets an active session for the given tenant, visitor_id and origin combination.
+  Gets latest active session for the given tenant_id, visitor_id and origin combination.
   Returns nil if no active session is found.
   """
-  def get_active_session(tenant, visitor_id, origin) do
+  def get_active_session(tenant_id, visitor_id, origin) do
     result =
       Repo.one(
         from s in Session,
           where:
-            s.tenant == ^tenant and
+            s.tenant_id == ^tenant_id and
               s.visitor_id == ^visitor_id and
               s.origin == ^origin and
               s.active == true,
@@ -92,8 +92,6 @@ defmodule Core.WebTracker.Sessions do
 
     result
   end
-
-
 
   @doc """
   Returns all closed sessions for a lead
@@ -298,7 +296,6 @@ defmodule Core.WebTracker.Sessions do
   # Create session with IP data
   defp create_session_with_ip_data(
          %{
-           tenant: tenant,
            tenant_id: tenant_id,
            visitor_id: visitor_id,
            origin: origin,
@@ -315,7 +312,6 @@ defmodule Core.WebTracker.Sessions do
          ip_data
        ) do
     session_attrs = %{
-      tenant: tenant,
       tenant_id: tenant_id,
       visitor_id: visitor_id,
       origin: origin,

--- a/lib/core/web_tracker/sessions.ex
+++ b/lib/core/web_tracker/sessions.ex
@@ -96,10 +96,10 @@ defmodule Core.WebTracker.Sessions do
   @doc """
   Returns all closed sessions for a lead
   """
-  def get_all_closed_sessions_by_tenant_and_company(tenant_name, company_id) do
+  def get_all_closed_sessions_by_tenant_and_company(tenant_id, company_id) do
     from(s in Session,
       where:
-        s.tenant == ^tenant_name and s.company_id == ^company_id and
+        s.tenant_id == ^tenant_id and s.company_id == ^company_id and
           s.active == false
     )
     |> Repo.all()

--- a/lib/core/web_tracker/sessions/session.ex
+++ b/lib/core/web_tracker/sessions/session.ex
@@ -95,7 +95,6 @@ defmodule Core.WebTracker.Sessions.Session do
   ]
 
   schema "web_sessions" do
-    field(:tenant, :string)
     field(:tenant_id, :string)
     field(:visitor_id, :string)
     field(:origin, :string)
@@ -129,7 +128,6 @@ defmodule Core.WebTracker.Sessions.Session do
 
   @type t :: %__MODULE__{
           id: String.t(),
-          tenant: String.t() | nil,
           tenant_id: String.t() | nil,
           visitor_id: String.t(),
           origin: String.t(),
@@ -170,7 +168,6 @@ defmodule Core.WebTracker.Sessions.Session do
     session
     |> cast(attrs, [
       :id,
-      :tenant,
       :tenant_id,
       :visitor_id,
       :origin,
@@ -193,7 +190,7 @@ defmodule Core.WebTracker.Sessions.Session do
       :utm_id,
       :paid_id
     ])
-    |> validate_required([:id, :visitor_id, :origin])
+    |> validate_required([:id, :visitor_id, :origin, :tenant_id])
     |> validate_format(:id, @id_regex)
   end
 end

--- a/lib/core/web_tracker/sessions/session.ex
+++ b/lib/core/web_tracker/sessions/session.ex
@@ -129,7 +129,7 @@ defmodule Core.WebTracker.Sessions.Session do
 
   @type t :: %__MODULE__{
           id: String.t(),
-          tenant: String.t(),
+          tenant: String.t() | nil,
           tenant_id: String.t() | nil,
           visitor_id: String.t(),
           origin: String.t(),
@@ -193,7 +193,7 @@ defmodule Core.WebTracker.Sessions.Session do
       :utm_id,
       :paid_id
     ])
-    |> validate_required([:id, :tenant, :visitor_id, :origin])
+    |> validate_required([:id, :visitor_id, :origin])
     |> validate_format(:id, @id_regex)
   end
 end

--- a/lib/web/controllers/google_ads_controller.ex
+++ b/lib/web/controllers/google_ads_controller.ex
@@ -76,7 +76,7 @@ defmodule Web.GoogleAdsController do
   defp handle_successful_oauth(conn, code, redirect_uri, tenant_id) do
     with {:ok, token} <- exchange_code_for_token(code, redirect_uri),
          {:ok, customer_id} <- GoogleAdsOAuth.get_customer_id(token.access_token),
-         {:ok, connection} <- create_google_ads_connection(token, customer_id, tenant_id) do
+         {:ok, _connection} <- create_google_ads_connection(token, customer_id, tenant_id) do
       conn
       |> put_flash(:success, "Successfully connected to Google Ads")
       |> redirect(to: ~p"/leads")
@@ -109,33 +109,33 @@ defmodule Web.GoogleAdsController do
   end
 
 
+  #TODO alexb un-comment this
+  # defp get_customer_id_and_update_connection(connection, token) do
+  #   case GoogleAdsOAuth.get_customer_id(token.access_token) do
+  #     {:ok, customer_id} ->
+  #       # Update the connection with the real customer ID
+  #       case Connections.update_connection(connection, %{
+  #              external_system_id: customer_id
+  #            }) do
+  #         {:ok, updated_connection} ->
+  #           Logger.info("Updated Google Ads connection with customer ID: #{customer_id}")
+  #           {:ok, customer_id}
 
-  defp get_customer_id_and_update_connection(connection, token) do
-    case GoogleAdsOAuth.get_customer_id(token.access_token) do
-      {:ok, customer_id} ->
-        # Update the connection with the real customer ID
-        case Connections.update_connection(connection, %{
-               external_system_id: customer_id
-             }) do
-          {:ok, updated_connection} ->
-            Logger.info("Updated Google Ads connection with customer ID: #{customer_id}")
-            {:ok, customer_id}
+  #         {:error, reason} ->
+  #           Logger.error("Failed to update connection with customer ID: #{inspect(reason)}")
+  #           {:error, :update_failed}
+  #       end
 
-          {:error, reason} ->
-            Logger.error("Failed to update connection with customer ID: #{inspect(reason)}")
-            {:error, :update_failed}
-        end
+  #     {:error, :no_customers_found} ->
+  #       # No accessible customers found
+  #       Logger.info("No accessible Google Ads customers found")
+  #       {:error, :no_customers_found}
 
-      {:error, :no_customers_found} ->
-        # No accessible customers found
-        Logger.info("No accessible Google Ads customers found")
-        {:error, :no_customers_found}
-
-      {:error, reason} ->
-        Logger.error("Failed to get Google Ads customer ID: #{inspect(reason)}")
-        {:error, :customer_id_failed}
-    end
-  end
+  #     {:error, reason} ->
+  #       Logger.error("Failed to get Google Ads customer ID: #{inspect(reason)}")
+  #       {:error, :customer_id_failed}
+  #   end
+  # end
 
   defp create_google_ads_connection(token, customer_id, tenant_id) do
     connection_params = %{

--- a/lib/web/controllers/google_ads_controller.ex
+++ b/lib/web/controllers/google_ads_controller.ex
@@ -75,20 +75,32 @@ defmodule Web.GoogleAdsController do
 
   defp handle_successful_oauth(conn, code, redirect_uri, tenant_id) do
     with {:ok, token} <- exchange_code_for_token(code, redirect_uri),
-         {:ok, customer_id} <- GoogleAdsOAuth.get_customer_id(token.access_token),
-         {:ok, _connection} <- create_google_ads_connection(token, customer_id, tenant_id) do
+         {:ok, customer_id} <-
+           GoogleAdsOAuth.get_customer_id(token.access_token),
+         {:ok, _connection} <-
+           create_google_ads_connection(token, customer_id, tenant_id) do
       conn
       |> put_flash(:success, "Successfully connected to Google Ads")
       |> redirect(to: ~p"/leads")
     else
       {:error, :no_customers_found} ->
         conn
-        |> put_flash(:error, "No accessible Google Ads customer accounts found for this user.")
+        |> put_flash(
+          :error,
+          "No accessible Google Ads customer accounts found for this user."
+        )
         |> redirect(to: ~p"/leads")
+
       {:error, reason} ->
-        Logger.error("Failed to complete Google Ads integration: #{inspect(reason)}")
+        Logger.error(
+          "Failed to complete Google Ads integration: #{inspect(reason)}"
+        )
+
         conn
-        |> put_flash(:error, "Failed to complete Google Ads integration: #{inspect(reason)}")
+        |> put_flash(
+          :error,
+          "Failed to complete Google Ads integration: #{inspect(reason)}"
+        )
         |> redirect(to: ~p"/leads")
     end
   end
@@ -108,8 +120,7 @@ defmodule Web.GoogleAdsController do
     end
   end
 
-
-  #TODO alexb un-comment this
+  # TODO alexb un-comment this
   # defp get_customer_id_and_update_connection(connection, token) do
   #   case GoogleAdsOAuth.get_customer_id(token.access_token) do
   #     {:ok, customer_id} ->
@@ -152,8 +163,12 @@ defmodule Web.GoogleAdsController do
 
     case Connections.create_connection(connection_params) do
       {:ok, connection} ->
-        Logger.info("Successfully created Google Ads connection: #{inspect(connection, pretty: true)}")
+        Logger.info(
+          "Successfully created Google Ads connection: #{inspect(connection, pretty: true)}"
+        )
+
         {:ok, connection}
+
       {:error, reason} ->
         Logger.error(
           "Failed to create Google Ads connection: #{inspect(reason)}"

--- a/priv/repo/migrations/20250711131607_set_tenant_nullable_in_web_session_and_web_tracker_events.exs
+++ b/priv/repo/migrations/20250711131607_set_tenant_nullable_in_web_session_and_web_tracker_events.exs
@@ -1,0 +1,27 @@
+defmodule Core.Repo.Migrations.SetTenantNullableInWebSessionAndWebTrackerEvents do
+  use Ecto.Migration
+
+  def up do
+    # Make tenant nullable in web_sessions table
+    alter table(:web_sessions) do
+      modify :tenant, :string, null: true
+    end
+
+    # Make tenant nullable in web_tracker_events table
+    alter table(:web_tracker_events) do
+      modify :tenant, :string, null: true
+    end
+  end
+
+  def down do
+    # Revert tenant to not null in web_sessions table
+    alter table(:web_sessions) do
+      modify :tenant, :string, null: false
+    end
+
+    # Revert tenant to not null in web_tracker_events table
+    alter table(:web_tracker_events) do
+      modify :tenant, :string, null: false
+    end
+  end
+end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Deprecates `tenant` column in `sessions` and `events` tables, replacing it with `tenant_id`, and updates related code and queries across modules.
> 
>   - **Database Changes**:
>     - Add migration `20250711131607_set_tenant_nullable_in_web_session_and_web_tracker_events.exs` to make `tenant` column nullable in `web_sessions` and `web_tracker_events` tables.
>   - **Code Refactoring**:
>     - Remove `tenant` column usage in favor of `tenant_id` across multiple modules including `builder.ex`, `leads.ex`, `lead_creator_job.ex`, `stage_evaluator.ex`, `engagement_profiler.ex`, `channel_classifier.ex`, `company_enrichment_job.ex`, `session_analyzer.ex`, `session_closer.ex`, `sessions.ex`, `session.ex`, `google_ads_controller.ex`.
>     - Remove unnecessary joins with `Tenant` in queries in `builder.ex`, `leads.ex`, `stage_evaluator.ex`, `engagement_profiler.ex`.
>     - Update functions to use `tenant_id` for operations and queries.
>   - **Miscellaneous**:
>     - Minor formatting changes in `runtime.exs` and `google_ads.ex`.
>     - Comment out unused function `get_customer_id_and_update_connection` in `google_ads_controller.ex`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for 2bf6e4374cd06d7fcd91f63aabbc9fd4a686d708. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->