### PR TITLE
patch: remove deprecated columns

### DIFF
--- a/lib/core/crm/companies/company.ex
+++ b/lib/core/crm/companies/company.ex
@@ -52,8 +52,6 @@ defmodule Core.Crm.Companies.Company do
     field(:scrapin_enrichment_attempts, :integer, default: 0)
 
     # LinkedIn fields
-    # deprecated
-    field(:linkedin_id, :string)
     field(:linkedin_ids, {:array, :string}, default: [])
 
     field(:homepage_scraped, :boolean, default: false)
@@ -92,7 +90,6 @@ defmodule Core.Crm.Companies.Company do
           icon_enrichment_attempts: integer(),
           business_model_enrichment_attempts: integer(),
           scrapin_enrichment_attempts: integer(),
-          linkedin_id: String.t() | nil,
           linkedin_ids: {:array, :string},
           domains: {:array, :string},
           homepage_scraped: boolean(),
@@ -133,7 +130,6 @@ defmodule Core.Crm.Companies.Company do
       :icon_enrichment_attempts,
       :business_model_enrichment_attempts,
       :scrapin_enrichment_attempts,
-      :linkedin_id,
       :linkedin_ids,
       :homepage_scraped,
       :technologies_used,

--- a/lib/core/crm/contacts.ex
+++ b/lib/core/crm/contacts.ex
@@ -461,8 +461,8 @@ defmodule Core.Crm.Contacts do
     end
   end
 
-  def get_tagret_persona_contacts_by_lead_id(tenant_id, lead_id) do
-    OpenTelemetry.Tracer.with_span "contacts.get_tagret_persona_contacts_by_lead_id" do
+  def get_target_persona_contacts_by_lead_id(tenant_id, lead_id) do
+    OpenTelemetry.Tracer.with_span "contacts.get_target_persona_contacts_by_lead_id" do
       OpenTelemetry.Tracer.set_attributes([
         {"param.tenant.id", tenant_id},
         {"param.lead.id", lead_id}

--- a/priv/repo/migrations/20250714090307_remove_linkedin_id_from_companies.exs
+++ b/priv/repo/migrations/20250714090307_remove_linkedin_id_from_companies.exs
@@ -1,0 +1,15 @@
+defmodule Core.Repo.Migrations.RemoveLinkedinIdFromCompanies do
+  use Ecto.Migration
+
+  def up do
+    alter table(:companies) do
+      remove :linkedin_id
+    end
+  end
+
+  def down do
+    alter table(:companies) do
+      add :linkedin_id, :string
+    end
+  end
+end

--- a/priv/repo/migrations/20250714091922_remove_tenant_from_web_sessions.exs
+++ b/priv/repo/migrations/20250714091922_remove_tenant_from_web_sessions.exs
@@ -1,0 +1,15 @@
+defmodule Core.Repo.Migrations.RemoveTenantFromWebSessions do
+  use Ecto.Migration
+
+  def up do
+    alter table(:web_sessions) do
+      remove :tenant
+    end
+  end
+
+  def down do
+    alter table(:web_sessions) do
+      add :tenant, :string
+    end
+  end
+end

--- a/priv/repo/migrations/20250714091940_remove_tenant_from_web_tracker_events.exs
+++ b/priv/repo/migrations/20250714091940_remove_tenant_from_web_tracker_events.exs
@@ -1,0 +1,15 @@
+defmodule Core.Repo.Migrations.RemoveTenantFromWebTrackerEvents do
+  use Ecto.Migration
+
+  def up do
+    alter table(:web_tracker_events) do
+      remove :tenant
+    end
+  end
+
+  def down do
+    alter table(:web_tracker_events) do
+      add :tenant, :string
+    end
+  end
+end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove deprecated columns `linkedin_id` and `tenant` from schemas and fix a typo in a function name.
> 
>   - **Schema Changes**:
>     - Remove `linkedin_id` from `companies` schema in `company.ex` and corresponding migration `20250714090307_remove_linkedin_id_from_companies.exs`.
>     - Remove `tenant` from `web_sessions` and `web_tracker_events` schemas with migrations `20250714091922_remove_tenant_from_web_sessions.exs` and `20250714091940_remove_tenant_from_web_tracker_events.exs`.
>   - **Code Fixes**:
>     - Fix typo in function name `get_tagret_persona_contacts_by_lead_id` to `get_target_persona_contacts_by_lead_id` in `contacts.ex`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for 4070fa6ed3631a63d8c4631ff38d2cb5bcbf1917. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->