### PR TITLE
patch: enable/disable tracking/stats

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(mix test)"
+    ],
+    "deny": []
+  }
+}

--- a/lib/core/analytics/job_scheduler.ex
+++ b/lib/core/analytics/job_scheduler.ex
@@ -19,7 +19,7 @@ defmodule Core.Analytics.JobScheduler do
   def schedule_future_jobs do
     Logger.info("Scheduling all analytics jobs for the next 24 hours...")
 
-    case Tenants.get_all_tenant_ids() do
+    case Tenants.get_tenant_ids_with_webtracker_available() do
       {:error, reason} ->
         Logger.error("Failed to get tenant ids: #{reason}")
         {:error, reason}

--- a/lib/core/auth/tenants.ex
+++ b/lib/core/auth/tenants.ex
@@ -20,6 +20,7 @@ defmodule Core.Auth.Tenants do
   @err_not_found {:error, "tenant not found"}
   @err_invalid_tenant_id {:error, "tenant id invalid"}
   @err_domain_exists {:error, "tenant domain already exists"}
+  @err_update_webtracker_status {:error, "failed to update webtracker status"}
 
   ## Database getters
 
@@ -69,6 +70,13 @@ defmodule Core.Auth.Tenants do
 
   def get_all_tenant_ids do
     case Repo.all(from t in Tenant, select: t.id) do
+      [] -> @err_not_found
+      tenant_ids -> {:ok, tenant_ids}
+    end
+  end
+
+  def get_tenant_ids_with_webtracker_available do
+    case Repo.all(from t in Tenant, where: t.webtracker_status == :available, select: t.id) do
       [] -> @err_not_found
       tenant_ids -> {:ok, tenant_ids}
     end
@@ -131,6 +139,23 @@ defmodule Core.Auth.Tenants do
 
       {:error, reason} ->
         {:error, reason}
+    end
+  end
+
+  def enable_webtracker(tenant_id) do
+    case get_tenant_by_id(tenant_id) do
+      {:ok, tenant} -> update_tenant(tenant, %{webtracker_status: :available})
+      _ -> @err_update_webtracker_status
+    end
+  end
+
+  def disable_webtracker(tenant_id) do
+    case get_tenant_by_id(tenant_id) do
+      {:ok, tenant} ->
+        update_tenant(tenant, %{webtracker_status: :not_available})
+
+      _ ->
+        @err_update_webtracker_status
     end
   end
 

--- a/lib/core/web_tracker/identify_event_handler.ex
+++ b/lib/core/web_tracker/identify_event_handler.ex
@@ -111,7 +111,7 @@ defmodule Core.WebTracker.IdentifyEventHandler do
 
       with {:ok, session} <- Sessions.get_session_by_id(event.session_id),
            true <- reassociation_needed?(session, domain),
-           {:ok, _} <- reassociate_company(event, domain) do
+           :ok <- reassociate_company(event, domain) do
         Tracing.ok()
         :ok
       else
@@ -122,6 +122,10 @@ defmodule Core.WebTracker.IdentifyEventHandler do
           )
 
           {:error, reason}
+
+        false ->
+          Tracing.ok()
+          :ok
       end
     end
   end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enable/disable web tracking for tenants, updating job scheduling and event handling to respect `webtracker_status`.
> 
>   - **Behavior**:
>     - `JobScheduler` in `job_scheduler.ex` now uses `get_tenant_ids_with_webtracker_available()` to schedule jobs only for tenants with web tracking enabled.
>     - `IdentifyEventHandler` in `identify_event_handler.ex` now returns `:ok` if reassociation is not needed, improving error handling.
>     - `OriginTenantMapper` in `origin_tenant_mapper.ex` checks `webtracker_status` and returns an error if web tracking is not enabled.
>   - **Functions**:
>     - Adds `enable_webtracker/1` and `disable_webtracker/1` to `tenants.ex` to update `webtracker_status`.
>     - Adds `get_tenant_ids_with_webtracker_available/0` to `tenants.ex` to retrieve tenant IDs with web tracking enabled.
>   - **Misc**:
>     - Adds error `@err_update_webtracker_status` in `tenants.ex` for failed web tracker status updates.
>     - Updates `settings.local.json` to allow `Bash(mix test)`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for 9cef15c5352beee90e48fb23859861f235cd18bf. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->