### PR TITLE
patch: fix self referral crash

### DIFF
--- a/lib/core/web_tracker/channel_classifier.ex
+++ b/lib/core/web_tracker/channel_classifier.ex
@@ -157,17 +157,22 @@ defmodule Core.WebTracker.ChannelClassifier do
   defp has_valid_referrer?(_), do: false
 
   defp self_referral?(tenant_domains, referrer) do
-    case DomainExtractor.extract_base_domain(referrer) do
-      {:ok, referrer_domain} ->
-        referrer_domain in tenant_domains
+    if String.starts_with?(referrer || "", "android-app://") or
+         String.starts_with?(referrer || "", "ios-app://") do
+      false
+    else
+      case DomainExtractor.extract_base_domain(referrer) do
+        {:ok, referrer_domain} ->
+          referrer_domain in tenant_domains
 
-      {:error, reason} ->
-        Logger.error("failed to determine if referrer is internal", %{
-          referrer: referrer,
-          reason: reason
-        })
+        {:error, reason} ->
+          Logger.error("failed to determine if referrer is internal", %{
+            referrer: referrer,
+            reason: reason
+          })
 
-        false
+          false
+      end
     end
   end
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes crash in `self_referral?` by handling `android-app://` and `ios-app://` schemes in `channel_classifier.ex`.
> 
>   - **Behavior**:
>     - Fixes crash in `self_referral?` in `channel_classifier.ex` by checking for `android-app://` and `ios-app://` URL schemes.
>     - Returns `false` for self-referrals with these schemes, preventing further processing.
>   - **Logging**:
>     - Logs an error if domain extraction fails, maintaining existing behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for 6e4e7de18c6be14ea338c53250fa9e83896db51d. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->