### PR TITLE
patch: set start date at company

### DIFF
--- a/lib/core/crm/contacts/contact.ex
+++ b/lib/core/crm/contacts/contact.ex
@@ -35,6 +35,7 @@ defmodule Core.Crm.Contacts.Contact do
     field(:summary, :string)
     field(:job_started_at, :utc_datetime)
     field(:job_ended_at, :utc_datetime)
+    field(:company_started_at, :utc_datetime)
     field(:seniority, :string)
     field(:department, :string)
     field(:email_enrich_requested_at, :utc_datetime)
@@ -71,6 +72,7 @@ defmodule Core.Crm.Contacts.Contact do
     :summary,
     :job_started_at,
     :job_ended_at,
+    :company_started_at,
     :seniority,
     :department,
     :email_enrich_requested_at,
@@ -106,6 +108,7 @@ defmodule Core.Crm.Contacts.Contact do
           summary: String.t() | nil,
           job_started_at: DateTime.t() | nil,
           job_ended_at: DateTime.t() | nil,
+          company_started_at: DateTime.t() | nil,
           seniority: String.t() | nil,
           department: String.t() | nil,
           email_enrich_requested_at: DateTime.t() | nil,

--- a/priv/repo/migrations/20250716184740_add_company_started_at_to_contacts.exs
+++ b/priv/repo/migrations/20250716184740_add_company_started_at_to_contacts.exs
@@ -1,0 +1,15 @@
+defmodule Core.Repo.Migrations.AddCompanyStartAtToContacts do
+  use Ecto.Migration
+
+  def up do
+    alter table(:contacts) do
+      add :company_started_at, :utc_datetime, null: true, after: :job_ended_at
+    end
+  end
+
+  def down do
+    alter table(:contacts) do
+      remove :company_started_at
+    end
+  end
+end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `company_started_at` field to `Contact` schema and update logic to handle it.
> 
>   - **Database Migration**:
>     - Adds `company_started_at` field to `contacts` table in `20250716184740_add_company_started_at_to_contacts.exs`.
>   - **Schema Changes**:
>     - Adds `company_started_at` field to `Contact` schema in `contact.ex`.
>   - **Logic Updates**:
>     - Updates `create_or_update_contact_for_position()` in `contacts.ex` to set `company_started_at` if it's earlier than existing value or not set.
>     - Modifies `extract_position_fields()` in `contacts.ex` to include `company_started_at` from `start_date`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for a9292eb50e4ba9655650a244fdf677b5485ee745. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->