### PR TITLE
patch: include metrics at ad level

### DIFF
--- a/lib/core/integrations/providers/google_ads/campaigns.ex
+++ b/lib/core/integrations/providers/google_ads/campaigns.ex
@@ -136,7 +136,18 @@ defmodule Core.Integrations.Providers.GoogleAds.Campaigns do
       ad_group_ad.status,
       ad_group_ad.resource_name,
       ad_group_ad.ad_group,
-      ad_group.resource_name
+      ad_group.resource_name,
+      metrics.cost_micros,
+      metrics.impressions,
+      metrics.clicks,
+      metrics.conversions,
+      metrics.conversions_value,
+      metrics.average_cpc,
+      metrics.ctr,
+      ad_group_ad.ad.responsive_search_ad.headlines,
+      ad_group_ad.ad.responsive_search_ad.descriptions,
+      ad_group_ad.ad.image_ad.image_url,
+      ad_group_ad.ad.display_url
     FROM ad_group_ad
     """
 
@@ -275,16 +286,37 @@ defmodule Core.Integrations.Providers.GoogleAds.Campaigns do
         Enum.map(results, fn result ->
           ad_group_ad = result["adGroupAd"]
           ad = ad_group_ad["ad"]
+          metrics = Map.get(result, "metrics", %{})
 
-          %{
+          base_data = %{
             "id" => ad["id"],
             "name" => ad["name"],
             "type" => ad["type"],
             "final_urls" => ad["finalUrls"],
             "status" => ad_group_ad["status"],
             "resource_name" => ad_group_ad["resourceName"],
-            "ad_group_resource_name" => ad_group_ad["adGroup"]
+            "ad_group_resource_name" => ad_group_ad["adGroup"],
+            "display_url" => ad["displayUrl"],
+            "responsive_search_ad" => %{
+              "headlines" => get_in(ad, ["responsiveSearchAd", "headlines"]),
+              "descriptions" => get_in(ad, ["responsiveSearchAd", "descriptions"])
+            },
+            "image_url" => get_in(ad, ["imageAd", "imageUrl"])
           }
+
+          if map_size(metrics) > 0 do
+            Map.put(base_data, "metrics", %{
+              "cost_micros" => metrics["costMicros"],
+              "impressions" => metrics["impressions"],
+              "clicks" => metrics["clicks"],
+              "conversions" => metrics["conversions"],
+              "conversions_value" => metrics["conversionsValue"],
+              "average_cpc" => metrics["averageCpc"],
+              "ctr" => metrics["ctr"]
+            })
+          else
+            base_data
+          end
         end)
 
       _ ->


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add ad-level metrics and details to Google Ads integration in `campaigns.ex`.
> 
>   - **Behavior**:
>     - Include ad-level metrics in `list_campaigns_for_customer` in `campaigns.ex`.
>     - Metrics added: `cost_micros`, `impressions`, `clicks`, `conversions`, `conversions_value`, `average_cpc`, `ctr`.
>     - Ad details expanded with `headlines`, `descriptions`, `image_url`, `display_url`.
>   - **Data Processing**:
>     - Update `process_ads_response` to handle new metrics and ad details.
>     - Modify SQL query in `list_campaigns_for_customer` to fetch additional metrics and ad details.
>   - **Misc**:
>     - No changes to campaign or ad group processing logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for bf59ca045999bae99f9ca9d6dcdad3272ce8a998. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->