### PR TITLE
patch: move icon rate limit errors to warning

### DIFF
--- a/lib/core/crm/companies/company_enrich.ex
+++ b/lib/core/crm/companies/company_enrich.ex
@@ -678,6 +678,15 @@ defmodule Core.Crm.Companies.CompanyEnrich do
           @err_image_not_found
         end
 
+      {:error, "HTTP request failed with status 429"} ->
+        Tracing.warning(:rate_limited, "Icon download rate limited, will retry later",
+          company_id: company.id,
+          company_domain: company.primary_domain
+        )
+
+        # Return a retryable error for rate limiting
+        {:error, :rate_limited}
+
       {:error, reason} ->
         Tracing.error(reason, "Failed to download icon for company",
           company_id: company.id,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Handle HTTP 429 errors as warnings in `download_company_icon/1` in `company_enrich.ex`, returning a retryable error.
> 
>   - **Behavior**:
>     - In `download_company_icon/1` in `company_enrich.ex`, HTTP 429 errors are now logged as warnings instead of errors.
>     - Returns `{:error, :rate_limited}` for HTTP 429 status, indicating a retryable error.
>   - **Logging**:
>     - Uses `Tracing.warning` for HTTP 429 status to log rate limiting as a warning with company details.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcore&utm_source=github&utm_medium=referral)<sup> for 1f188ac48b6ac06782236dc2608463de4e0ecc4a. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->